### PR TITLE
Add more button to ThankYou screen

### DIFF
--- a/src/components/kiosk/ThankYouScreen.tsx
+++ b/src/components/kiosk/ThankYouScreen.tsx
@@ -2,11 +2,12 @@
 "use client";
 
 import Image from 'next/image';
-import { ReceiptText, Smile, Clock } from 'lucide-react';
+import { ReceiptText, Smile, Clock, Map } from 'lucide-react';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import type { Language, t as TFunction } from '@/lib/translations';
 
 interface ThankYouScreenProps {
@@ -20,6 +21,7 @@ interface ThankYouScreenProps {
 const AUTO_RESET_SECONDS = 60;
 
 export function ThankYouScreen({ receiptType, onNewSession, lang, t, onLanguageSwitch }: ThankYouScreenProps) {
+  const router = useRouter();
   const [countdown, setCountdown] = useState(AUTO_RESET_SECONDS);
 
   useEffect(() => {
@@ -45,6 +47,10 @@ export function ThankYouScreen({ receiptType, onNewSession, lang, t, onLanguageS
     </Button>
   );
 
+  const handleMore = () => {
+    router.push('/store-map');
+  };
+
   return (
     <FullScreenCard 
       title={t("thankYou.title")} 
@@ -60,6 +66,14 @@ export function ThankYouScreen({ receiptType, onNewSession, lang, t, onLanguageS
       <ReceiptText size={100} className="text-secondary mb-10 opacity-50" />
 
       <KioskButton onClick={onNewSession} label={t("thankYou.button.newSession")} />
+      <Button
+        variant="outline"
+        onClick={handleMore}
+        className="bg-card text-primary border-primary hover:bg-primary/10 text-lg py-3 px-6 mt-4 flex items-center gap-2"
+      >
+        {t("thankYou.button.more")}
+        <Map className="ml-2 h-5 w-5" />
+      </Button>
       
       <div className="flex items-center text-sm text-muted-foreground mt-6">
         <Clock size={16} className="mr-2"/>

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -333,6 +333,7 @@ export const translations: Record<string, Record<Language, string>> = {
   "thankYou.message.enjoyCharge": { ko: "충전을 즐기십시오! 이 화면은 곧 초기화됩니다.", en: "Enjoy your charge! This screen will reset shortly." },
   "thankYou.message.smsSent": { ko: "영수증이 SMS로 전송되었습니다. 이 화면은 곧 초기화됩니다.", en: "Your receipt has been sent via SMS. This screen will reset shortly." },
   "thankYou.button.newSession": { ko: "새 충전 세션 시작", en: "Start New Charging Session" },
+  "thankYou.button.more": { ko: "더보기", en: "More" },
   "thankYou.autoResetMessage": { ko: "{{seconds}}초 후 자동 초기화...", en: "Auto-reset in {{seconds}} seconds..." },
 
   // === QueueScreen ===


### PR DESCRIPTION
## Summary
- add new translation key for a map-style More button
- link the Thank You screen to the store map
- style the More button like the existing map buttons

## Testing
- `npm run lint` *(fails: interactive configuration prompt)*
- `npm run typecheck` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_685372d771c483268ee3d5cca648d7b1