### PR TITLE
Fix map flow from thank you screen

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,0 +1,21 @@
+
+"use client";
+
+import { Suspense } from 'react';
+import StoreMapContent from '../../components/kiosk/StoreMapContent';
+import { Loader2 } from 'lucide-react';
+
+export default function StoreMapPage() {
+  return (
+    <Suspense 
+      fallback={
+        <div className="w-screen h-screen flex flex-col items-center justify-center bg-background text-foreground p-6">
+          <Loader2 className="h-12 w-12 animate-spin text-primary mb-4" />
+          <p className="text-xl text-muted-foreground">Loading map data...</p>
+        </div>
+      }
+    >
+      <StoreMapContent />
+    </Suspense>
+  );
+}

--- a/src/components/kiosk/LocalBusinessDisplay.tsx
+++ b/src/components/kiosk/LocalBusinessDisplay.tsx
@@ -15,7 +15,7 @@ export function LocalBusinessDisplay({ lang, t }: LocalBusinessDisplayProps) {
   const router = useRouter();
 
   const handleShowAllOnMap = () => {
-    router.push('/store-map');
+    router.push('/map', { shallow: true });
   };
 
   return (

--- a/src/components/kiosk/StoreMapContent.tsx
+++ b/src/components/kiosk/StoreMapContent.tsx
@@ -320,7 +320,7 @@ export default function StoreMapContent() {
         }}
       >
         <button
-          onClick={() => router.push("/charging")} // ✅ 여기 수정
+          onClick={() => router.back()}
           style={{
             width: "360px",
             padding: "14px 0",

--- a/src/components/kiosk/ThankYouScreen.tsx
+++ b/src/components/kiosk/ThankYouScreen.tsx
@@ -48,7 +48,7 @@ export function ThankYouScreen({ receiptType, onNewSession, lang, t, onLanguageS
   );
 
   const handleMore = () => {
-    router.push('/store-map');
+    router.push('/map', { shallow: true });
   };
 
   return (


### PR DESCRIPTION
## Summary
- open `/map` with shallow routing from LocalBusinessDisplay and ThankYouScreen
- return to previous page when closing map view
- expose `/map` route

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck` *(fails: 34 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685375458c248326ad5af0ee44d12061