### PR TITLE
Add TTS prompts

### DIFF
--- a/src/components/kiosk/ChargingInProgressScreen.tsx
+++ b/src/components/kiosk/ChargingInProgressScreen.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState, useRef } from "react";
 import type { Language } from "@/lib/translations";
 import { t as TFunction } from "@/lib/translations";
 import { cn } from "@/lib/utils";
+import { useTTS } from "@/hooks/useTTS";
 
 interface ChargingInProgressScreenProps {
   slotNumber: string;
@@ -59,6 +60,12 @@ export function ChargingInProgressScreen({
   onLanguageSwitch,
   selectedConnectorType,
 }: ChargingInProgressScreenProps) {
+  const { speak } = useTTS();
+  useEffect(() => {
+    speak(
+      "충전이 진행 중입니다. 필요 시 중지하거나 문제 해결 버튼을 눌러주세요. 시스템 보호를 위해 강제로 커넥터를 제거하지 마세요. 충전이 완료될 때까지 기다려 주세요."
+    );
+  }, []);
   const loadStateFromSessionStorage = (): StoredChargingState | null => {
     if (typeof window !== "undefined") {
       const saved = sessionStorage.getItem(SESSION_STORAGE_KEY);

--- a/src/components/kiosk/ConfirmStartChargingScreen.tsx
+++ b/src/components/kiosk/ConfirmStartChargingScreen.tsx
@@ -7,6 +7,7 @@ import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
 import type { Language, t as TFunction } from '@/lib/translations';
+import { useTTS } from '@/hooks/useTTS';
 
 interface ConfirmStartChargingScreenProps {
   onStart: () => void;
@@ -21,6 +22,10 @@ const COUNTDOWN_SECONDS = 10;
 export function ConfirmStartChargingScreen({ onStart, onCancel, lang, t, onLanguageSwitch }: ConfirmStartChargingScreenProps) {
   const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const { speak } = useTTS();
+  useEffect(() => {
+    speak("충전 준비가 완료되었습니다. 곧 충전이 시작됩니다.");
+  }, []);
 
   useEffect(() => {
     timerRef.current = setInterval(() => {

--- a/src/components/kiosk/DataConsentScreen.tsx
+++ b/src/components/kiosk/DataConsentScreen.tsx
@@ -7,6 +7,8 @@ import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
 import type { Language } from '@/lib/translations';
 import type { t as TFunction } from '@/lib/translations';
+import { useEffect } from 'react';
+import { useTTS } from '@/hooks/useTTS';
 import { Card, CardContent } from '@/components/ui/card'; 
 // Removed CardHeader, CardTitle as they are not used for the inner card.
 
@@ -21,6 +23,10 @@ interface DataConsentScreenProps {
 }
 
 export function DataConsentScreen({ onAgree, onDisagree, disagreeTapCount, lang, t, onLanguageSwitch }: DataConsentScreenProps) {
+  const { speak } = useTTS();
+  useEffect(() => {
+    speak("개인정보 수집 및 이용에 동의해 주세요.");
+  }, []);
   const languageButton = (
     <Button
       onClick={onLanguageSwitch}

--- a/src/components/kiosk/InitialPromptConnectScreen.tsx
+++ b/src/components/kiosk/InitialPromptConnectScreen.tsx
@@ -8,6 +8,8 @@ import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
 import type { VehicleInfo } from '@/types/kiosk';
 import type { Language, t as TFunction } from '@/lib/translations';
+import { useEffect } from 'react';
+import { useTTS } from '@/hooks/useTTS';
 
 interface InitialPromptConnectScreenProps {
   vehicleInfo: VehicleInfo;
@@ -21,6 +23,10 @@ interface InitialPromptConnectScreenProps {
 export function InitialPromptConnectScreen({ vehicleInfo, slotNumber, onChargerConnected, lang, t, onLanguageSwitch }: InitialPromptConnectScreenProps) {
   const vehicleModelDisplay = vehicleInfo.model ? t(vehicleInfo.model) : t('selectCarModel.unknownModel');
   const portLocationDisplay = vehicleInfo.portLocationDescription ? t(vehicleInfo.portLocationDescription) : "";
+  const { speak } = useTTS();
+  useEffect(() => {
+    speak("테슬라 Y: 좌측 뒤에 라이트쪽에 충전구가 있습니다.");
+  }, []);
 
    let connectionImagePath = vehicleInfo.connectionImageUrl;
 

--- a/src/components/kiosk/InitialWelcomeScreen.tsx
+++ b/src/components/kiosk/InitialWelcomeScreen.tsx
@@ -6,6 +6,8 @@ import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
 import type { Language, t as TFunction } from '@/lib/translations';
+import { useEffect } from 'react';
+import { useTTS } from '@/hooks/useTTS';
 
 interface InitialWelcomeScreenProps {
   onProceedStandard: () => void;
@@ -15,6 +17,10 @@ interface InitialWelcomeScreenProps {
 }
 
 export function InitialWelcomeScreen({ onProceedStandard, lang, t, onLanguageSwitch }: InitialWelcomeScreenProps) {
+  const { speak } = useTTS();
+  useEffect(() => {
+    speak("EV 충전 서비스를 시작합니다. 화면을 터치하거나 ‘시작’이라고 말씀해주세요.");
+  }, []);
   const languageButton = (
     <Button
       onClick={onLanguageSwitch}

--- a/src/components/kiosk/PaymentScreen.tsx
+++ b/src/components/kiosk/PaymentScreen.tsx
@@ -6,8 +6,9 @@ import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
 import type { BillDetails } from '@/types/kiosk'; // types/kiosk.ts 파일도 수정했음을 가정
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { Language, t as TFunction } from '@/lib/translations'; // translations.ts 파일도 수정했음을 가정
+import { useTTS } from '@/hooks/useTTS';
 
 interface PaymentScreenProps {
   bill: BillDetails;
@@ -23,6 +24,19 @@ type PaymentMethod = 'card' | 'nfc' | null;
 export function PaymentScreen({ bill, onPaymentProcessed, lang, t, onLanguageSwitch }: PaymentScreenProps) {
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<PaymentMethod>(null);
   const [paymentStatus, setPaymentStatus] = useState<'pending' | 'processing' | 'success'>('pending');
+  const { speak } = useTTS();
+
+  useEffect(() => {
+    if (paymentStatus === 'pending') {
+      speak('충전이 완료되었습니다. 결제를 진행합니다. 결제가 완료되면 충전 커넥터를 분리해 주세요.');
+    }
+  }, [paymentStatus]);
+
+  useEffect(() => {
+    if (paymentStatus === 'success') {
+      speak('결제가 완료되었습니다. 영수증을 인쇄하거나 화면에서 확인할 수 있습니다.');
+    }
+  }, [paymentStatus]);
 
   const handlePaymentMethodSelect = (method: PaymentMethod) => {
     setSelectedPaymentMethod(method);

--- a/src/components/kiosk/PrePaymentAuthScreen.tsx
+++ b/src/components/kiosk/PrePaymentAuthScreen.tsx
@@ -5,8 +5,9 @@ import { CreditCard, Nfc } from 'lucide-react';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { Language, t as TFunction } from '@/lib/translations';
+import { useTTS } from '@/hooks/useTTS';
 
 interface PrePaymentAuthScreenProps {
   onAuthSuccess: () => void;
@@ -19,6 +20,10 @@ interface PrePaymentAuthScreenProps {
 export function PrePaymentAuthScreen({ onAuthSuccess, onCancel, lang, t, onLanguageSwitch }: PrePaymentAuthScreenProps) {
   const [isProcessing, setIsProcessing] = useState(false);
   const [processingMethod, setProcessingMethod] = useState<'card' | 'nfc' | null>(null);
+  const { speak } = useTTS();
+  useEffect(() => {
+    speak("결제를 진행하기 전에 인증을 완료해 주세요.");
+  }, []);
 
   const handleSimulatePayment = (method: 'card' | 'nfc') => {
     setProcessingMethod(method);

--- a/src/components/kiosk/SelectConnectorTypeScreen.tsx
+++ b/src/components/kiosk/SelectConnectorTypeScreen.tsx
@@ -33,7 +33,7 @@ export function SelectConnectorTypeScreen({
   const { speak } = useTTS();
 
   useEffect(() => {
-    speak("차량에 맞는 충전 커넥터 유형을 선택해주세요.");
+    speak("차량에 맞는 충전 커넥터를 선택해 주세요.");
   }, []);
 
   const recommendedTypeId = vehicleInfo?.recommendedConnectorType;

--- a/src/components/kiosk/ThankYouScreen.tsx
+++ b/src/components/kiosk/ThankYouScreen.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { Language, t as TFunction } from '@/lib/translations';
+import { useTTS } from '@/hooks/useTTS';
 
 interface ThankYouScreenProps {
   receiptType?: 'sms' | 'none';
@@ -23,6 +24,10 @@ const AUTO_RESET_SECONDS = 60;
 export function ThankYouScreen({ receiptType, onNewSession, lang, t, onLanguageSwitch }: ThankYouScreenProps) {
   const router = useRouter();
   const [countdown, setCountdown] = useState(AUTO_RESET_SECONDS);
+  const { speak } = useTTS();
+  useEffect(() => {
+    speak('이용해 주셔서 감사합니다. 안전 운전하세요.');
+  }, []);
 
   useEffect(() => {
     const timer = setInterval(() => {

--- a/src/components/kiosk/VehicleConfirmationScreen.tsx
+++ b/src/components/kiosk/VehicleConfirmationScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { CheckCircle2, Edit3 } from 'lucide-react';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
@@ -9,6 +9,7 @@ import type { VehicleInfo } from '@/types/kiosk';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import type { Language, t as TFunction } from '@/lib/translations';
+import { useTTS } from '@/hooks/useTTS';
 
 interface VehicleConfirmationScreenProps {
   vehicleInfo: VehicleInfo;
@@ -29,6 +30,10 @@ export function VehicleConfirmationScreen({
 }: VehicleConfirmationScreenProps) {
   const [isManualEntryMode, setIsManualEntryMode] = useState(false);
   const [manualPlateInput, setManualPlateInput] = useState("");
+  const { speak } = useTTS();
+  useEffect(() => {
+    speak("차량 번호가 맞으신가요? 예 또는 아니요를 눌러주세요.");
+  }, []);
 
   const handleManualSubmit = () => {
   if (manualPlateInput.trim() === "") return;


### PR DESCRIPTION
## Summary
- add TTS messages to all kiosk screens

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68537ced79e48326a56459ff459118d2