### PR TITLE
Fix map return screen

### DIFF
--- a/src/components/kiosk/LocalBusinessDisplay.tsx
+++ b/src/components/kiosk/LocalBusinessDisplay.tsx
@@ -16,6 +16,9 @@ export function LocalBusinessDisplay({ lang, t, from }: LocalBusinessDisplayProp
   const router = useRouter();
 
   const handleShowAllOnMap = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('kioskReturnState', 'CHARGING_IN_PROGRESS');
+    }
     router.push('/map');
   };
 

--- a/src/components/kiosk/StoreMapContent.tsx
+++ b/src/components/kiosk/StoreMapContent.tsx
@@ -320,7 +320,7 @@ export default function StoreMapContent() {
         }}
       >
         <button
-          onClick={() => router.back()}
+          onClick={() => router.push('/')}
           style={{
             width: "360px",
             padding: "14px 0",

--- a/src/components/kiosk/ThankYouScreen.tsx
+++ b/src/components/kiosk/ThankYouScreen.tsx
@@ -53,6 +53,9 @@ export function ThankYouScreen({ receiptType, onNewSession, lang, t, onLanguageS
   );
 
   const handleMore = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('kioskReturnState', 'THANK_YOU');
+    }
     router.push('/map');
   };
 


### PR DESCRIPTION
## Summary
- maintain last screen state when opening map
- return to previous screen instead of history
- adjust map screen back button

## Testing
- `npm run lint` *(fails: interactive config prompt)*
- `npm run typecheck` *(fails: type errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6853819957508326bbdd47761d4d77d6