### PR TITLE
Fix manual license plate navigation flow

### DIFF
--- a/src/components/kiosk/ManualPlateInputScreen.tsx
+++ b/src/components/kiosk/ManualPlateInputScreen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
@@ -18,6 +19,7 @@ interface ManualPlateInputScreenProps {
 
 export function ManualPlateInputScreen({ onSubmit, onCancel, lang, t, onLanguageSwitch }: ManualPlateInputScreenProps) {
   const [plate, setPlate] = useState('');
+  const router = useRouter();
 
   const languageButton = (
     <Button
@@ -33,6 +35,7 @@ export function ManualPlateInputScreen({ onSubmit, onCancel, lang, t, onLanguage
     const trimmed = plate.trim().toUpperCase();
     if (trimmed) {
       onSubmit(trimmed);
+      router.push('/select-car-brand');
     }
   };
 

--- a/src/components/kiosk/MapModal.tsx
+++ b/src/components/kiosk/MapModal.tsx
@@ -1,4 +1,23 @@
+"use client";
 
-// This file is no longer needed and can be deleted.
-// If you have a process to automatically delete files listed with no content,
-// this will be handled. Otherwise, please remove this file manually.
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import React from 'react';
+
+interface MapModalProps {
+  children?: React.ReactNode;
+}
+
+export function MapModal({ children }: MapModalProps) {
+  const router = useRouter();
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded-lg shadow-lg max-w-lg w-full">
+        {children}
+        <div className="mt-4 flex justify-end">
+          <Button onClick={() => router.back()}>뒤로가기</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/kiosk/SelectCarBrandScreen.tsx
+++ b/src/components/kiosk/SelectCarBrandScreen.tsx
@@ -3,6 +3,7 @@
 
 import Image from 'next/image';
 import { Car } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
@@ -20,6 +21,7 @@ interface SelectCarBrandScreenProps {
 }
 
 export function SelectCarBrandScreen({ brands, onBrandSelect, onCancel, lang, t, onLanguageSwitch }: SelectCarBrandScreenProps) {
+  const router = useRouter();
   const languageButton = (
     <Button
       onClick={onLanguageSwitch}
@@ -45,9 +47,17 @@ export function SelectCarBrandScreen({ brands, onBrandSelect, onCancel, lang, t,
           <Card 
             key={brand.id} 
             className="p-4 flex flex-col items-center justify-center hover:shadow-lg cursor-pointer aspect-square transition-all hover:bg-muted/50"
-            onClick={() => onBrandSelect(brand.id)}
+            onClick={() => {
+              onBrandSelect(brand.id);
+              router.push('/select-car-model');
+            }}
             tabIndex={0}
-            onKeyDown={(e) => e.key === 'Enter' && onBrandSelect(brand.id)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                onBrandSelect(brand.id);
+                router.push('/select-car-model');
+              }
+            }}
             aria-label={t(brand.name)}
           >
             <Image 

--- a/src/components/kiosk/SelectCarModelScreen.tsx
+++ b/src/components/kiosk/SelectCarModelScreen.tsx
@@ -3,6 +3,7 @@
 
 import Image from 'next/image';
 import { CarIcon } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
@@ -21,6 +22,7 @@ interface SelectCarModelScreenProps {
 }
 
 export function SelectCarModelScreen({ brand, onModelSelect, onCancel, lang, t, onLanguageSwitch }: SelectCarModelScreenProps) {
+  const router = useRouter();
   const languageButton = (
     <Button
       onClick={onLanguageSwitch}
@@ -78,19 +80,27 @@ export function SelectCarModelScreen({ brand, onModelSelect, onCancel, lang, t, 
         {brand.models.map((model) => {
           const modelDisplayName = t(model.name);
           return (
-            <Card 
-              key={model.id} 
+            <Card
+              key={model.id}
               className={cardClasses}
-              onClick={() => onModelSelect({
-                  model: model.name, 
-                  licensePlate: 'selectCarModel.manualEntryLicensePlate', 
+              onClick={() => {
+                onModelSelect({
+                  model: model.name,
+                  licensePlate: 'selectCarModel.manualEntryLicensePlate',
                   confidence: 1.0,
-                  portLocationDescription: "selectCarModel.portLocationGeneric", 
+                  portLocationDescription: "selectCarModel.portLocationGeneric",
                   connectionImageUrl: 'https://placehold.co/600x400.png', // Placeholder image, actual image size can vary
                   dataAiHint: model.dataAiHint || "electric vehicle",
-              })}
+                });
+                router.push('/preauth');
+              }}
               tabIndex={0}
-              onKeyDown={(e) => e.key === 'Enter' && onModelSelect({ model: model.name, licensePlate: 'selectCarModel.manualEntryLicensePlate' })}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  onModelSelect({ model: model.name, licensePlate: 'selectCarModel.manualEntryLicensePlate' });
+                  router.push('/preauth');
+                }
+              }}
               aria-label={modelDisplayName}
             >
               <div className="w-full h-32 relative mb-1"> 

--- a/src/components/kiosk/StoreMapContent.tsx
+++ b/src/components/kiosk/StoreMapContent.tsx
@@ -320,7 +320,7 @@ export default function StoreMapContent() {
         }}
       >
         <button
-          onClick={() => router.push('/')}
+          onClick={() => router.back()}
           style={{
             width: "360px",
             padding: "14px 0",

--- a/src/components/kiosk/VehicleConfirmationScreen.tsx
+++ b/src/components/kiosk/VehicleConfirmationScreen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { CheckCircle2, Edit3 } from 'lucide-react';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
@@ -28,6 +29,7 @@ export function VehicleConfirmationScreen({
   t,
   onLanguageSwitch,
 }: VehicleConfirmationScreenProps) {
+  const router = useRouter();
   const [isManualEntryMode, setIsManualEntryMode] = useState(false);
   const [manualPlateInput, setManualPlateInput] = useState("");
   const { speak } = useTTS();
@@ -127,7 +129,12 @@ export function VehicleConfirmationScreen({
 
       <div className="w-full max-w-md space-y-4">
         <KioskButton onClick={() => onConfirm(vehicleInfo)} label={t("vehicleConfirmation.button.confirm")} icon={<CheckCircle2 />} />
-        <KioskButton onClick={() => setIsManualEntryMode(true)} label={t("vehicleConfirmation.button.manualEntry")} variant="outline" icon={<Edit3 />} />
+        <KioskButton
+          onClick={() => router.push('/manual-plate-input')}
+          label={t("vehicleConfirmation.button.manualEntry")}
+          variant="outline"
+          icon={<Edit3 />}
+        />
       </div>
     </FullScreenCard>
   );


### PR DESCRIPTION
## Summary
- navigate to manual plate entry via Next.js router
- route between manual entry, brand/model selection, and pre-auth screens
- allow map screen to go back to the previous page
- add simple MapModal component with back navigation

## Testing
- `npm run typecheck` *(fails: Cannot find module and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685385fb360083269a5fdfd4a0eef080