### PR TITLE
Implement fast start kiosk flow pages

### DIFF
--- a/src/app/assign-slot/page.tsx
+++ b/src/app/assign-slot/page.tsx
@@ -1,0 +1,5 @@
+'use client';
+import { SlotAssignmentScreen } from '@/components/kiosk/SlotAssignmentScreen';
+export default function AssignSlotPage() {
+  return <SlotAssignmentScreen />;
+}

--- a/src/app/complete/page.tsx
+++ b/src/app/complete/page.tsx
@@ -1,0 +1,5 @@
+'use client';
+import { ThankYouScreen } from '@/components/kiosk/ThankYouScreen';
+export default function CompletePage() {
+  return <ThankYouScreen />;
+}

--- a/src/app/confirm-start/page.tsx
+++ b/src/app/confirm-start/page.tsx
@@ -1,0 +1,5 @@
+'use client';
+import { ConfirmStartChargingScreen } from '@/components/kiosk/ConfirmStartChargingScreen';
+export default function ConfirmStartPage() {
+  return <ConfirmStartChargingScreen />;
+}

--- a/src/app/manual-plate-input/page.tsx
+++ b/src/app/manual-plate-input/page.tsx
@@ -1,0 +1,5 @@
+'use client';
+import { ManualPlateInputScreen } from '@/components/kiosk/ManualPlateInputScreen';
+export default function ManualPlateInputPage() {
+  return <ManualPlateInputScreen />;
+}

--- a/src/app/payment/page.tsx
+++ b/src/app/payment/page.tsx
@@ -1,0 +1,5 @@
+'use client';
+import { PaymentScreen } from '@/components/kiosk/PaymentScreen';
+export default function PaymentPage() {
+  return <PaymentScreen />;
+}

--- a/src/app/select-connector-type/page.tsx
+++ b/src/app/select-connector-type/page.tsx
@@ -1,0 +1,5 @@
+'use client';
+import { SelectConnectorTypeScreen } from '@/components/kiosk/SelectConnectorTypeScreen';
+export default function SelectConnectorTypePage() {
+  return <SelectConnectorTypeScreen />;
+}

--- a/src/components/kiosk/InitialWelcomeScreen.tsx
+++ b/src/components/kiosk/InitialWelcomeScreen.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import type { Language } from '@/lib/translations';
 import { useEffect } from 'react';
 import { useTTS } from '@/hooks/useTTS';
+import { useRouter } from 'next/navigation';
 
 interface InitialWelcomeScreenProps {
   onProceedStandard: () => void;
@@ -17,6 +18,7 @@ interface InitialWelcomeScreenProps {
 }
 
 export function InitialWelcomeScreen({ onProceedStandard, lang, t, onLanguageSwitch }: InitialWelcomeScreenProps) {
+  const router = useRouter();
   const { speak } = useTTS();
   useEffect(() => {
     speak("EV 충전 서비스를 시작합니다. 화면을 터치하거나 ‘시작’이라고 말씀해주세요.");
@@ -47,6 +49,12 @@ export function InitialWelcomeScreen({ onProceedStandard, lang, t, onLanguageSwi
           label={t("initialWelcome.proceedButtonStandard")}
           icon={<PlayCircle />}
         />
+        <Button
+          onClick={() => router.push('/manual-plate-input')}
+          className="w-full text-white bg-blue-800 hover:bg-blue-700"
+        >
+          ⚡ 빠른 시작
+        </Button>
       </div>
       {/* Removed the auto-switch message paragraph */}
     </FullScreenCard>


### PR DESCRIPTION
## Summary
- add Quick Start button that routes to manual plate input
- create pages for manual plate input, connector type selection, slot assignment, confirm start, payment, and completion

## Testing
- `npm run lint` *(fails: ESLint configuration prompt)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68539e83d2088326890dc92b1e002d56