### PR TITLE
Fix translation hook usage

### DIFF
--- a/src/app/manual-plate-input/page.tsx
+++ b/src/app/manual-plate-input/page.tsx
@@ -1,5 +1,16 @@
 'use client';
 import { ManualPlateInputScreen } from '@/components/kiosk/ManualPlateInputScreen';
+import { useRouter } from 'next/navigation';
+
 export default function ManualPlateInputPage() {
-  return <ManualPlateInputScreen />;
+  const router = useRouter();
+
+  return (
+    <ManualPlateInputScreen
+      lang="ko"
+      onLanguageSwitch={() => {}}
+      onSubmit={() => {}}
+      onCancel={() => router.push('/')}
+    />
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -545,7 +545,14 @@ const handleConsentDisagree = () => {
       case 'DATA_CONSENT':
         return <DataConsentScreen {...screenProps} onAgree={handleConsentAgree} onDisagree={handleConsentDisagree} disagreeTapCount={disagreeTapCount} />;
       case 'MANUAL_PLATE_INPUT':
-        return <ManualPlateInputScreen {...screenProps} onSubmit={handleManualPlateSubmitted} onCancel={resetToInitialWelcome} />;
+        return (
+          <ManualPlateInputScreen
+            lang={appData.language}
+            onLanguageSwitch={handleLanguageSwitch}
+            onSubmit={handleManualPlateSubmitted}
+            onCancel={resetToInitialWelcome}
+          />
+        );
       case 'SELECT_CAR_BRAND':
         return <SelectCarBrandScreen {...screenProps} brands={MOCK_CAR_BRANDS} onBrandSelect={handleBrandSelected} onCancel={resetToInitialWelcome} />;
       case 'SELECT_CAR_MODEL':

--- a/src/components/kiosk/ManualPlateInputScreen.tsx
+++ b/src/components/kiosk/ManualPlateInputScreen.tsx
@@ -8,16 +8,17 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Edit3 } from 'lucide-react';
 import type { Language } from '@/lib/translations';
+import { useTranslations } from '@/hooks/useTranslations';
 
 interface ManualPlateInputScreenProps {
   onSubmit: (plate: string) => void;
   onCancel: () => void;
   lang: Language;
-  t: (key: string, params?: Record<string, string | number>) => string;
   onLanguageSwitch: () => void;
 }
 
-export function ManualPlateInputScreen({ onSubmit, onCancel, lang, t, onLanguageSwitch }: ManualPlateInputScreenProps) {
+export function ManualPlateInputScreen({ onSubmit, onCancel, lang, onLanguageSwitch }: ManualPlateInputScreenProps) {
+  const { t } = useTranslations();
   const [plate, setPlate] = useState('');
   const router = useRouter();
 

--- a/src/hooks/useTranslations.ts
+++ b/src/hooks/useTranslations.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Language, t as translate } from '@/lib/translations';
+
+/**
+ * Simple hook to provide translation function based on language stored in
+ * localStorage ("kioskLanguage"). Falls back to Korean ("ko").
+ */
+export function useTranslations() {
+  const [lang, setLang] = useState<Language>('ko');
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('kioskLanguage') as Language | null;
+      if (stored) {
+        setLang(stored);
+      }
+    }
+  }, []);
+
+  const t = useCallback(
+    (key: string, params?: Record<string, string | number>) =>
+      translate(lang, key, params),
+    [lang]
+  );
+
+  return { t, lang, setLang };
+}


### PR DESCRIPTION
## Summary
- implement `useTranslations` hook for simple language handling
- update `ManualPlateInputScreen` to use the hook
- adjust kiosk screen rendering for manual plate input
- provide props in manual plate input page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853a377394c832698b68eb97277505c