### PR TITLE
Unify quick start button style

### DIFF
--- a/src/components/kiosk/InitialWelcomeScreen.tsx
+++ b/src/components/kiosk/InitialWelcomeScreen.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { Handshake, PlayCircle } from 'lucide-react';
+import { Handshake, PlayCircle, Zap } from 'lucide-react';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
@@ -49,12 +49,12 @@ export function InitialWelcomeScreen({ onProceedStandard, lang, t, onLanguageSwi
           label={t("initialWelcome.proceedButtonStandard")}
           icon={<PlayCircle />}
         />
-        <Button
+        <KioskButton
           onClick={() => router.push('/manual-plate-input')}
-          className="w-full text-white bg-blue-800 hover:bg-blue-700"
-        >
-          ⚡ 빠른 시작
-        </Button>
+          label={t('initialWelcome.proceedButtonQuick')}
+          icon={<Zap />}
+          variant="secondary"
+        />
       </div>
       {/* Removed the auto-switch message paragraph */}
     </FullScreenCard>


### PR DESCRIPTION
## Summary
- match the size and styling of the Quick Start button with the Service Guide start button

## Testing
- `npm test` *(fails: missing script)*
- `npm run typecheck` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6853a57a116c8326b1758d49579a1970