### PR TITLE
Fix translation hook usage and add manual plate route alias

### DIFF
--- a/src/app/manual-plate-input/page.tsx
+++ b/src/app/manual-plate-input/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 import { ManualPlateInputScreen } from '@/components/kiosk/ManualPlateInputScreen';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from '@/hooks/useTranslations';
 
 export default function ManualPlateInputPage() {
   const router = useRouter();
+  const { t } = useTranslations();
 
   return (
     <ManualPlateInputScreen
       lang="ko"
+      t={t}
       onLanguageSwitch={() => {}}
       onSubmit={() => {}}
       onCancel={() => router.push('/')}

--- a/src/app/manual-plate/page.tsx
+++ b/src/app/manual-plate/page.tsx
@@ -1,0 +1,2 @@
+'use client';
+export { default } from '../manual-plate-input/page';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -548,6 +548,7 @@ const handleConsentDisagree = () => {
         return (
           <ManualPlateInputScreen
             lang={appData.language}
+            t={t}
             onLanguageSwitch={handleLanguageSwitch}
             onSubmit={handleManualPlateSubmitted}
             onCancel={resetToInitialWelcome}

--- a/src/components/kiosk/ManualPlateInputScreen.tsx
+++ b/src/components/kiosk/ManualPlateInputScreen.tsx
@@ -8,17 +8,16 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Edit3 } from 'lucide-react';
 import type { Language } from '@/lib/translations';
-import { useTranslations } from '@/hooks/useTranslations';
 
 interface ManualPlateInputScreenProps {
   onSubmit: (plate: string) => void;
   onCancel: () => void;
   lang: Language;
+  t: (key: string, params?: Record<string, string | number>) => string;
   onLanguageSwitch: () => void;
 }
 
-export function ManualPlateInputScreen({ onSubmit, onCancel, lang, onLanguageSwitch }: ManualPlateInputScreenProps) {
-  const { t } = useTranslations();
+export function ManualPlateInputScreen({ onSubmit, onCancel, lang, t, onLanguageSwitch }: ManualPlateInputScreenProps) {
   const [plate, setPlate] = useState('');
   const router = useRouter();
 


### PR DESCRIPTION
## Summary
- ensure ManualPlateInputScreen receives translation function via props
- pass translation function from kiosk page and manual page
- add `/manual-plate` alias for manual plate input screen

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a6a058748326becf9447bc1a8cac