### PR TITLE
Fix button size with consistent styling

### DIFF
--- a/src/components/kiosk/InitialWelcomeScreen.tsx
+++ b/src/components/kiosk/InitialWelcomeScreen.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { Handshake, PlayCircle } from 'lucide-react';
+import { Handshake, PlayCircle, Zap } from 'lucide-react';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
@@ -49,12 +49,11 @@ export function InitialWelcomeScreen({ onProceedStandard, lang, t, onLanguageSwi
           label={t("initialWelcome.proceedButtonStandard")}
           icon={<PlayCircle />}
         />
-        <Button
+        <KioskButton
           onClick={() => router.push('/manual-plate-input')}
-          className="w-full text-white bg-blue-800 hover:bg-blue-700"
-        >
-          ⚡ 빠른 시작
-        </Button>
+          label={t("initialWelcome.proceedButtonQuick")}
+          icon={<Zap />}
+        />
       </div>
       {/* Removed the auto-switch message paragraph */}
     </FullScreenCard>


### PR DESCRIPTION
## Summary
- apply the same kiosk button styling for the quick start button

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6853a95c17188326b5d4571ed2fbcba9