### PR TITLE
Fix quick start translation

### DIFF
--- a/src/app/manual-plate-input/page.tsx
+++ b/src/app/manual-plate-input/page.tsx
@@ -1,5 +1,63 @@
 'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { ManualPlateInputScreen } from '@/components/kiosk/ManualPlateInputScreen';
+import { Language, t as translateFunction } from '@/lib/translations';
+
 export default function ManualPlateInputPage() {
-  return <ManualPlateInputScreen />;
+  const router = useRouter();
+  const [lang, setLang] = useState<Language>('ko');
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+    const storedLang = localStorage.getItem('kioskLanguage') as Language | null;
+    if (storedLang) {
+      setLang(storedLang);
+      document.documentElement.lang = storedLang;
+    } else {
+      document.documentElement.lang = 'ko';
+    }
+  }, []);
+
+  const t = useCallback(
+    (key: string, params?: Record<string, string | number>) => {
+      return translateFunction(lang, key, params);
+    },
+    [lang]
+  );
+
+  const handleLanguageSwitch = useCallback(() => {
+    const newLang = lang === 'ko' ? 'en' : 'ko';
+    setLang(newLang);
+    localStorage.setItem('kioskLanguage', newLang);
+    document.documentElement.lang = newLang;
+  }, [lang]);
+
+  const handleSubmit = useCallback(
+    (plate: string) => {
+      console.log('License plate submitted:', plate);
+      router.push('/select-car-brand');
+    },
+    [router]
+  );
+
+  const handleCancel = useCallback(() => {
+    router.push('/');
+  }, [router]);
+
+  if (!isClient) {
+    return null;
+  }
+
+  return (
+    <ManualPlateInputScreen
+      onSubmit={handleSubmit}
+      onCancel={handleCancel}
+      lang={lang}
+      t={t}
+      onLanguageSwitch={handleLanguageSwitch}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- repair manual-plate-input page by supplying lang handling

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6853ae530ef48326ba4211f0bd855aba