### PR TITLE
Fix translation hook usage in manual flow pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,8 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
-import type { KioskState, VehicleInfo, ChargingSlot, AppData, ConnectorTypeInfo, CarBrand, CarModel, BillDetails, OperatingMode } from '@/types/kiosk';
+import type { KioskState, VehicleInfo, ChargingSlot, AppData, ConnectorTypeInfo, BillDetails, OperatingMode } from '@/types/kiosk';
+import type { CarBrand, CarModel } from '@/types/kiosk';
 import { useToast } from "@/hooks/use-toast";
 import { Language, t as translateFunction } from '@/lib/translations';
 
@@ -28,43 +29,13 @@ import { ThankYouScreen } from '@/components/kiosk/ThankYouScreen';
 import { ChargingErrorScreen } from '@/components/kiosk/ChargingErrorScreen';
 import Image from 'next/image';
 import chargingImage from '/public/assets/images/charging.png';
-
-
-const MOCK_CAR_MODELS_HYUNDAI: CarModel[] = [
-  { id: 'ioniq5', name: 'carModel.hyundai.ioniq5', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai Ioniq5' },
-  { id: 'kona_ev', name: 'carModel.hyundai.kona_ev', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai KonaEV' },
-  { id: 'ioniq6', name: 'carModel.hyundai.ioniq6', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai Ioniq6' },
-  { id: 'nexo', name: 'carModel.hyundai.nexo', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai Nexo' },
-  { id: 'casper_ev', name: 'carModel.hyundai.casper_ev', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai CasperEV' },
-  { id: 'porter_ev', name: 'carModel.hyundai.porter_ev', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai PorterEV' },
-];
-const MOCK_CAR_MODELS_KIA: CarModel[] = [
-  { id: 'ev6', name: 'carModel.kia.ev6', imageUrl: '/images/ev6.jpg', dataAiHint: 'Kia EV6' },
-  { id: 'niro_ev', name: 'carModel.kia.niro_ev', imageUrl: '/images/niro ev.png', dataAiHint: 'Kia NiroEV' },
-  { id: 'ev9', name: 'carModel.kia.ev9', imageUrl: "/images/ev9.jpg", dataAiHint: 'Kia EV9' },
-  { id: 'ev4', name: 'carModel.kia.ev4', imageUrl: "/images/ev4.png", dataAiHint: 'Kia SoulEV' },
-  { id: 'ray_ev', name: 'carModel.kia.ray_ev', imageUrl: "/images/Ray ev.jpg", dataAiHint: 'Kia RayEV' },
-  { id: 'ev5', name: 'carModel.kia.ev5', imageUrl: "/images/ev5.jpg", dataAiHint: 'Kia BongoEV' },
-];
-const MOCK_CAR_MODELS_KG: CarModel[] = [
-  { id: 'torres_evx', name: 'carModel.kgm.torres_evx  ', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'KG TorresEVX' },
-  { id: 'korando_emotion', name: 'carModel.kgm.korando_emotion', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'KG Korando' },
-];
-const MOCK_CAR_MODELS_TESLA: CarModel[] = [
-  { id: 'model_3', name: 'carModel.tesla.model_3', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla Model3' },
-  { id: 'model_y', name: 'carModel.tesla.model_y', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla ModelY' },
-  { id: 'model_s', name: 'carModel.tesla.model_s', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla ModelS' },
-  { id: 'model_x', name: 'carModel.tesla.model_x', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla ModelX' },
-  { id: 'cybertruck', name: 'carModel.tesla.cybertruck', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla Cybertruck' },
-  { id: 'roadster', name: 'carModel.tesla.roadster', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla Roadster' },
-];
-
-const MOCK_CAR_BRANDS: CarBrand[] = [
-  { id: 'hyundai', name: 'carBrand.hyundai', logoUrl: '/images/logos/hyundai.png', dataAiHint: 'Hyundai logo', models: MOCK_CAR_MODELS_HYUNDAI },//나중에 경로 변경
-  { id: 'kia', name: 'carBrand.kia', logoUrl: '/images/logos/kia.png', dataAiHint: 'Kia logo', models: MOCK_CAR_MODELS_KIA },
-  { id: 'kgm', name: 'carBrand.kgm', logoUrl: '/images/logos/KGM.png', dataAiHint: 'KGMobility logo', models: MOCK_CAR_MODELS_KG },
-  { id: 'tesla', name: 'carBrand.tesla', logoUrl: '/images/logos/TESLR.png', dataAiHint: 'Tesla logo', models: MOCK_CAR_MODELS_TESLA },
-];
+import {
+  MOCK_CAR_BRANDS,
+  MOCK_CAR_MODELS_HYUNDAI,
+  MOCK_CAR_MODELS_KIA,
+  MOCK_CAR_MODELS_KG,
+  MOCK_CAR_MODELS_TESLA,
+} from '@/lib/mockData';
 
 const MOCK_VEHICLE_DATA: VehicleInfo = {
   licensePlate: `데모-${Math.floor(Math.random() * 900) + 100}`,

--- a/src/app/preauth/page.tsx
+++ b/src/app/preauth/page.tsx
@@ -1,6 +1,56 @@
 'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { PrePaymentAuthScreen } from '@/components/kiosk/PrePaymentAuthScreen';
+import { Language, t as translateFunction } from '@/lib/translations';
 
 export default function PrePaymentAuthPage() {
-  return <PrePaymentAuthScreen />;
+  const router = useRouter();
+  const [lang, setLang] = useState<Language>('ko');
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+    const storedLang = localStorage.getItem('kioskLanguage') as Language | null;
+    if (storedLang) {
+      setLang(storedLang);
+      document.documentElement.lang = storedLang;
+    } else {
+      document.documentElement.lang = 'ko';
+    }
+  }, []);
+
+  const t = useCallback((key: string, params?: Record<string, string | number>) => {
+    return translateFunction(lang, key, params);
+  }, [lang]);
+
+  const handleLanguageSwitch = useCallback(() => {
+    const newLang = lang === 'ko' ? 'en' : 'ko';
+    setLang(newLang);
+    localStorage.setItem('kioskLanguage', newLang);
+    document.documentElement.lang = newLang;
+  }, [lang]);
+
+  const handleAuthSuccess = useCallback(() => {
+    router.push('/charging');
+  }, [router]);
+
+  const handleCancel = useCallback(() => {
+    router.push('/select-car-model');
+  }, [router]);
+
+  if (!isClient) {
+    return null;
+  }
+
+  return (
+    <PrePaymentAuthScreen
+      onAuthSuccess={handleAuthSuccess}
+      onCancel={handleCancel}
+      lang={lang}
+      t={t}
+      onLanguageSwitch={handleLanguageSwitch}
+    />
+  );
 }

--- a/src/app/select-car-brand/page.tsx
+++ b/src/app/select-car-brand/page.tsx
@@ -1,6 +1,58 @@
 'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { SelectCarBrandScreen } from '@/components/kiosk/SelectCarBrandScreen';
+import { Language, t as translateFunction } from '@/lib/translations';
+import { MOCK_CAR_BRANDS } from '@/lib/mockData';
 
 export default function SelectCarBrandPage() {
-  return <SelectCarBrandScreen />;
+  const router = useRouter();
+  const [lang, setLang] = useState<Language>('ko');
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+    const storedLang = localStorage.getItem('kioskLanguage') as Language | null;
+    if (storedLang) {
+      setLang(storedLang);
+      document.documentElement.lang = storedLang;
+    } else {
+      document.documentElement.lang = 'ko';
+    }
+  }, []);
+
+  const t = useCallback((key: string, params?: Record<string, string | number>) => {
+    return translateFunction(lang, key, params);
+  }, [lang]);
+
+  const handleLanguageSwitch = useCallback(() => {
+    const newLang = lang === 'ko' ? 'en' : 'ko';
+    setLang(newLang);
+    localStorage.setItem('kioskLanguage', newLang);
+    document.documentElement.lang = newLang;
+  }, [lang]);
+
+  const handleBrandSelect = useCallback((brandId: string) => {
+    router.push(`/select-car-model?brand=${brandId}`);
+  }, [router]);
+
+  const handleCancel = useCallback(() => {
+    router.push('/manual-plate-input');
+  }, [router]);
+
+  if (!isClient) {
+    return null;
+  }
+
+  return (
+    <SelectCarBrandScreen
+      brands={MOCK_CAR_BRANDS}
+      onBrandSelect={handleBrandSelect}
+      onCancel={handleCancel}
+      lang={lang}
+      t={t}
+      onLanguageSwitch={handleLanguageSwitch}
+    />
+  );
 }

--- a/src/app/select-car-model/page.tsx
+++ b/src/app/select-car-model/page.tsx
@@ -1,6 +1,62 @@
 'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { SelectCarModelScreen } from '@/components/kiosk/SelectCarModelScreen';
+import { Language, t as translateFunction } from '@/lib/translations';
+import { MOCK_CAR_BRANDS } from '@/lib/mockData';
 
 export default function SelectCarModelPage() {
-  return <SelectCarModelScreen />;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [lang, setLang] = useState<Language>('ko');
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+    const storedLang = localStorage.getItem('kioskLanguage') as Language | null;
+    if (storedLang) {
+      setLang(storedLang);
+      document.documentElement.lang = storedLang;
+    } else {
+      document.documentElement.lang = 'ko';
+    }
+  }, []);
+
+  const t = useCallback((key: string, params?: Record<string, string | number>) => {
+    return translateFunction(lang, key, params);
+  }, [lang]);
+
+  const handleLanguageSwitch = useCallback(() => {
+    const newLang = lang === 'ko' ? 'en' : 'ko';
+    setLang(newLang);
+    localStorage.setItem('kioskLanguage', newLang);
+    document.documentElement.lang = newLang;
+  }, [lang]);
+
+  const handleModelSelect = useCallback(() => {
+    router.push('/preauth');
+  }, [router]);
+
+  const handleCancel = useCallback(() => {
+    router.push('/select-car-brand');
+  }, [router]);
+
+  const brandId = searchParams.get('brand');
+  const brand = MOCK_CAR_BRANDS.find(b => b.id === brandId);
+
+  if (!isClient) {
+    return null;
+  }
+
+  return (
+    <SelectCarModelScreen
+      brand={brand}
+      onModelSelect={handleModelSelect}
+      onCancel={handleCancel}
+      lang={lang}
+      t={t}
+      onLanguageSwitch={handleLanguageSwitch}
+    />
+  );
 }

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -1,0 +1,40 @@
+import type { CarBrand, CarModel } from '@/types/kiosk';
+
+export const MOCK_CAR_MODELS_HYUNDAI: CarModel[] = [
+  { id: 'ioniq5', name: 'carModel.hyundai.ioniq5', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai Ioniq5' },
+  { id: 'kona_ev', name: 'carModel.hyundai.kona_ev', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai KonaEV' },
+  { id: 'ioniq6', name: 'carModel.hyundai.ioniq6', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai Ioniq6' },
+  { id: 'nexo', name: 'carModel.hyundai.nexo', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai Nexo' },
+  { id: 'casper_ev', name: 'carModel.hyundai.casper_ev', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai CasperEV' },
+  { id: 'porter_ev', name: 'carModel.hyundai.porter_ev', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Hyundai PorterEV' },
+];
+
+export const MOCK_CAR_MODELS_KIA: CarModel[] = [
+  { id: 'ev6', name: 'carModel.kia.ev6', imageUrl: '/images/ev6.jpg', dataAiHint: 'Kia EV6' },
+  { id: 'niro_ev', name: 'carModel.kia.niro_ev', imageUrl: '/images/niro ev.png', dataAiHint: 'Kia NiroEV' },
+  { id: 'ev9', name: 'carModel.kia.ev9', imageUrl: '/images/ev9.jpg', dataAiHint: 'Kia EV9' },
+  { id: 'ev4', name: 'carModel.kia.ev4', imageUrl: '/images/ev4.png', dataAiHint: 'Kia SoulEV' },
+  { id: 'ray_ev', name: 'carModel.kia.ray_ev', imageUrl: '/images/Ray ev.jpg', dataAiHint: 'Kia RayEV' },
+  { id: 'ev5', name: 'carModel.kia.ev5', imageUrl: '/images/ev5.jpg', dataAiHint: 'Kia BongoEV' },
+];
+
+export const MOCK_CAR_MODELS_KG: CarModel[] = [
+  { id: 'torres_evx', name: 'carModel.kgm.torres_evx  ', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'KG TorresEVX' },
+  { id: 'korando_emotion', name: 'carModel.kgm.korando_emotion', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'KG Korando' },
+];
+
+export const MOCK_CAR_MODELS_TESLA: CarModel[] = [
+  { id: 'model_3', name: 'carModel.tesla.model_3', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla Model3' },
+  { id: 'model_y', name: 'carModel.tesla.model_y', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla ModelY' },
+  { id: 'model_s', name: 'carModel.tesla.model_s', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla ModelS' },
+  { id: 'model_x', name: 'carModel.tesla.model_x', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla ModelX' },
+  { id: 'cybertruck', name: 'carModel.tesla.cybertruck', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla Cybertruck' },
+  { id: 'roadster', name: 'carModel.tesla.roadster', imageUrl: 'https://placehold.co/400x300.png', dataAiHint: 'Tesla Roadster' },
+];
+
+export const MOCK_CAR_BRANDS: CarBrand[] = [
+  { id: 'hyundai', name: 'carBrand.hyundai', logoUrl: '/images/logos/hyundai.png', dataAiHint: 'Hyundai logo', models: MOCK_CAR_MODELS_HYUNDAI },
+  { id: 'kia', name: 'carBrand.kia', logoUrl: '/images/logos/kia.png', dataAiHint: 'Kia logo', models: MOCK_CAR_MODELS_KIA },
+  { id: 'kgm', name: 'carBrand.kgm', logoUrl: '/images/logos/KGM.png', dataAiHint: 'KGMobility logo', models: MOCK_CAR_MODELS_KG },
+  { id: 'tesla', name: 'carBrand.tesla', logoUrl: '/images/logos/TESLR.png', dataAiHint: 'Tesla logo', models: MOCK_CAR_MODELS_TESLA },
+];


### PR DESCRIPTION
## Summary
- add mock data module for car brands and models
- load brand data from new module
- implement language and translation hooks on select-car-brand
- support brand choice and language in select-car-model
- wire language/translation props on preauth screen

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6853b1a951188326a8cfd399e0d9b37e