### PR TITLE
Add voice command for next

### DIFF
--- a/src/components/kiosk/VoiceRecognitionButton.tsx
+++ b/src/components/kiosk/VoiceRecognitionButton.tsx
@@ -76,6 +76,25 @@ export function VoiceRecognitionButton() {
   } else if (normalized.includes("설정")) {
     speak("설정 화면으로 이동합니다.");
     router.push("/settings");
+  } else if (
+    normalized.includes("다음") ||
+    normalized.includes("next") ||
+    normalized.includes("다음페이지")
+  ) {
+    const nextButton = document.querySelector(
+      'button[data-variant="default"]:not([aria-label="Start voice recognition"])'
+    ) as HTMLButtonElement | null;
+    if (nextButton) {
+      speak("다음 단계로 이동합니다.");
+      nextButton.click();
+    } else {
+      speak("다음 단계로 이동할 수 없습니다.");
+      toast({
+        title: "다음 단계 없음",
+        description: "이 화면에서는 다음 단계 버튼을 찾을 수 없습니다.",
+        variant: "destructive",
+      });
+    }
   } else {
     toast({
       title: "명령어 인식 실패",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -45,6 +45,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
+        data-variant={variant}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
## Summary
- expose button variant through a `data-variant` attribute
- allow saying "다음" or "next" to activate the primary button on each page

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853b33936c083269c465516cfef9d19