### PR TITLE
Implement automatic STT for kiosk screens

### DIFF
--- a/src/components/kiosk/ChargingInProgressScreen.tsx
+++ b/src/components/kiosk/ChargingInProgressScreen.tsx
@@ -17,6 +17,7 @@ import type { Language } from "@/lib/translations";
 import { t as TFunction } from "@/lib/translations";
 import { cn } from "@/lib/utils";
 import { useTTS } from "@/hooks/useTTS";
+import { useAutoSTT } from "@/hooks/useAutoSTT";
 
 interface ChargingInProgressScreenProps {
   slotNumber: string;
@@ -282,6 +283,11 @@ export function ChargingInProgressScreen({
       setTimeout(() => onStopChargingRef.current(currentBill), 0);
     }
   };
+
+  useAutoSTT({
+    '충전중지': handleManualStop,
+    '문제발생': handleSimulateErrorClick,
+  });
 
   const handleSimulateErrorClick = () => {
     if (chargeIntervalRef.current) {

--- a/src/components/kiosk/ConfirmStartChargingScreen.tsx
+++ b/src/components/kiosk/ConfirmStartChargingScreen.tsx
@@ -8,6 +8,7 @@ import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
 import type { Language } from '@/lib/translations';
 import { useTTS } from '@/hooks/useTTS';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 
 interface ConfirmStartChargingScreenProps {
   onStart: () => void;
@@ -54,6 +55,8 @@ export function ConfirmStartChargingScreen({ onStart, onCancel, lang, t, onLangu
     if (timerRef.current) clearInterval(timerRef.current);
     onCancel();
   }
+
+  useAutoSTT({ '충전시작': handleManualStart });
 
   const languageButton = (
     <Button

--- a/src/components/kiosk/DataConsentScreen.tsx
+++ b/src/components/kiosk/DataConsentScreen.tsx
@@ -9,6 +9,7 @@ import type { Language } from '@/lib/translations';
 
 import { useEffect } from 'react';
 import { useTTS } from '@/hooks/useTTS';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 import { Card, CardContent } from '@/components/ui/card'; 
 // Removed CardHeader, CardTitle as they are not used for the inner card.
 
@@ -24,6 +25,10 @@ interface DataConsentScreenProps {
 
 export function DataConsentScreen({ onAgree, onDisagree, disagreeTapCount, lang, t, onLanguageSwitch }: DataConsentScreenProps) {
   const { speak } = useTTS();
+  useAutoSTT({
+    '동의합니다': onAgree,
+    '비동의합니다': onDisagree,
+  });
   useEffect(() => {
     speak("개인정보 수집 및 이용에 동의해 주세요.");
   }, []);

--- a/src/components/kiosk/InitialPromptConnectScreen.tsx
+++ b/src/components/kiosk/InitialPromptConnectScreen.tsx
@@ -10,6 +10,7 @@ import type { VehicleInfo } from '@/types/kiosk';
 import type { Language } from '@/lib/translations';
 import { useEffect } from 'react';
 import { useTTS } from '@/hooks/useTTS';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 
 interface InitialPromptConnectScreenProps {
   vehicleInfo: VehicleInfo;
@@ -24,6 +25,7 @@ export function InitialPromptConnectScreen({ vehicleInfo, slotNumber, onChargerC
   const vehicleModelDisplay = vehicleInfo.model ? t(vehicleInfo.model) : t('selectCarModel.unknownModel');
   const portLocationDisplay = vehicleInfo.portLocationDescription ? t(vehicleInfo.portLocationDescription) : "";
   const { speak } = useTTS();
+  useAutoSTT({ '연결했어': onChargerConnected });
   useEffect(() => {
     speak("테슬라 Y: 좌측 뒤에 라이트쪽에 충전구가 있습니다.");
   }, []);

--- a/src/components/kiosk/InitialWelcomeScreen.tsx
+++ b/src/components/kiosk/InitialWelcomeScreen.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import type { Language } from '@/lib/translations';
 import { useEffect } from 'react';
 import { useTTS } from '@/hooks/useTTS';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 import { useRouter } from 'next/navigation';
 
 interface InitialWelcomeScreenProps {
@@ -20,6 +21,10 @@ interface InitialWelcomeScreenProps {
 export function InitialWelcomeScreen({ onProceedStandard, lang, t, onLanguageSwitch }: InitialWelcomeScreenProps) {
   const router = useRouter();
   const { speak } = useTTS();
+  useAutoSTT({
+    '서비스시작': onProceedStandard,
+    '빠른시작': () => router.push('/manual-plate-input'),
+  });
   useEffect(() => {
     speak("EV 충전 서비스를 시작합니다. 화면을 터치하거나 ‘시작’이라고 말씀해주세요.");
   }, []);

--- a/src/components/kiosk/LocalBusinessDisplay.tsx
+++ b/src/components/kiosk/LocalBusinessDisplay.tsx
@@ -5,6 +5,7 @@ import { Map } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import CarbonComparison from './CarbonComparison'; // 새로 만든 컴포넌트 import
 import type { Language } from '@/lib/translations';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 
 interface LocalBusinessDisplayProps {
   lang: Language;
@@ -14,6 +15,10 @@ interface LocalBusinessDisplayProps {
 
 export function LocalBusinessDisplay({ lang, t, from }: LocalBusinessDisplayProps) {
   const router = useRouter();
+  useAutoSTT({
+    '뒤로가기': () => router.back(),
+    '닫기': () => router.back(),
+  });
 
   const handleShowAllOnMap = () => {
     if (typeof window !== 'undefined') {

--- a/src/components/kiosk/ManualPlateInputScreen.tsx
+++ b/src/components/kiosk/ManualPlateInputScreen.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Edit3 } from 'lucide-react';
 import type { Language } from '@/lib/translations';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 
 interface ManualPlateInputScreenProps {
   onSubmit: (plate: string) => void;
@@ -38,6 +39,11 @@ export function ManualPlateInputScreen({ onSubmit, onCancel, lang, t, onLanguage
       router.push('/select-car-brand');
     }
   };
+
+  useAutoSTT({
+    '제출': handleSubmit,
+    '취소': onCancel,
+  });
 
   return (
     <FullScreenCard title={t('manualPlateInput.title')} bottomCenterAccessory={languageButton}>

--- a/src/components/kiosk/PaymentScreen.tsx
+++ b/src/components/kiosk/PaymentScreen.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useState, useEffect } from 'react';
 import type { Language } from '@/lib/translations'; // translations.ts 파일도 수정했음을 가정
 import { useTTS } from '@/hooks/useTTS';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 
 interface PaymentScreenProps {
   bill: BillDetails;
@@ -44,6 +45,11 @@ export function PaymentScreen({ bill, onPaymentProcessed, lang, t, onLanguageSwi
       setPaymentStatus('success');
     }, 2000);
   };
+
+  useAutoSTT({
+    '결제해줘': () => handlePaymentMethodSelect('card'),
+    '카드로결제': () => handlePaymentMethodSelect('card'),
+  });
   
   const languageButton = (
     <Button

--- a/src/components/kiosk/PrePaymentAuthScreen.tsx
+++ b/src/components/kiosk/PrePaymentAuthScreen.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { useState, useEffect } from 'react';
 import type { Language } from '@/lib/translations';
 import { useTTS } from '@/hooks/useTTS';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 
 interface PrePaymentAuthScreenProps {
   onAuthSuccess: () => void;
@@ -30,10 +31,15 @@ export function PrePaymentAuthScreen({ onAuthSuccess, onCancel, lang, t, onLangu
     setIsProcessing(true);
     setTimeout(() => {
       onAuthSuccess();
-      setIsProcessing(false); 
+      setIsProcessing(false);
       setProcessingMethod(null);
     }, 2000);
   };
+
+  useAutoSTT({
+    '카드결제': () => handleSimulatePayment('card'),
+    '모바일결제': () => handleSimulatePayment('nfc'),
+  });
   
   const languageButton = (
     <Button

--- a/src/components/kiosk/SelectCarBrandScreen.tsx
+++ b/src/components/kiosk/SelectCarBrandScreen.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import type { CarBrand } from '@/types/kiosk';
 import { Card } from '@/components/ui/card';
 import type { Language } from '@/lib/translations';
+import { useAutoSTT, STTCommands } from '@/hooks/useAutoSTT';
 
 interface SelectCarBrandScreenProps {
   brands: CarBrand[];
@@ -22,6 +23,16 @@ interface SelectCarBrandScreenProps {
 
 export function SelectCarBrandScreen({ brands, onBrandSelect, onCancel, lang, t, onLanguageSwitch }: SelectCarBrandScreenProps) {
   const router = useRouter();
+  const commandMap: STTCommands = {};
+  brands.forEach((brand) => {
+    const phrase = t(brand.name);
+    commandMap[phrase] = () => {
+      onBrandSelect(brand.id);
+      router.push('/select-car-model');
+    };
+  });
+  commandMap['취소'] = onCancel;
+  useAutoSTT(commandMap);
   const languageButton = (
     <Button
       onClick={onLanguageSwitch}

--- a/src/components/kiosk/SelectCarModelScreen.tsx
+++ b/src/components/kiosk/SelectCarModelScreen.tsx
@@ -11,6 +11,7 @@ import type { CarBrand, VehicleInfo } from '@/types/kiosk';
 import { Card } from '@/components/ui/card';
 import type { Language } from '@/lib/translations';
 import { cn } from '@/lib/utils';
+import { useAutoSTT, STTCommands } from '@/hooks/useAutoSTT';
 
 interface SelectCarModelScreenProps {
   brand: CarBrand | undefined;
@@ -23,6 +24,18 @@ interface SelectCarModelScreenProps {
 
 export function SelectCarModelScreen({ brand, onModelSelect, onCancel, lang, t, onLanguageSwitch }: SelectCarModelScreenProps) {
   const router = useRouter();
+  const commandMap: STTCommands = {};
+  if (brand) {
+    brand.models.forEach((model) => {
+      const phrase = t(model.name);
+      commandMap[phrase] = () => {
+        onModelSelect({ model: model.name, licensePlate: 'selectCarModel.manualEntryLicensePlate' });
+        router.push('/preauth');
+      };
+    });
+  }
+  commandMap['취소'] = onCancel;
+  useAutoSTT(commandMap);
   const languageButton = (
     <Button
       onClick={onLanguageSwitch}

--- a/src/components/kiosk/SelectConnectorTypeScreen.tsx
+++ b/src/components/kiosk/SelectConnectorTypeScreen.tsx
@@ -10,6 +10,7 @@ import type { ConnectorTypeInfo, VehicleInfo } from '@/types/kiosk';
 import { Badge } from '@/components/ui/badge';
 import type { Language } from '@/lib/translations';
 import { useTTS } from '@/hooks/useTTS'; // ✅ TTS 훅 import
+import { useAutoSTT, STTCommands } from '@/hooks/useAutoSTT';
 
 interface SelectConnectorTypeScreenProps {
   vehicleInfo: VehicleInfo | null;
@@ -21,9 +22,9 @@ interface SelectConnectorTypeScreenProps {
   onLanguageSwitch: () => void;
 }
 
-export function SelectConnectorTypeScreen({ 
-  vehicleInfo, 
-  availableConnectors, 
+export function SelectConnectorTypeScreen({
+  vehicleInfo,
+  availableConnectors,
   onConnectorSelect,
   onCancel,
   lang,
@@ -31,6 +32,13 @@ export function SelectConnectorTypeScreen({
   onLanguageSwitch
 }: SelectConnectorTypeScreenProps) {
   const { speak } = useTTS();
+  const commandMap: STTCommands = {};
+  availableConnectors.forEach((c) => {
+    const phrase = t(c.name);
+    commandMap[phrase] = () => onConnectorSelect(c.id);
+  });
+  commandMap['취소'] = onCancel;
+  useAutoSTT(commandMap);
 
   useEffect(() => {
     speak("차량에 맞는 충전 커넥터를 선택해 주세요.");

--- a/src/components/kiosk/StoreMapContent.tsx
+++ b/src/components/kiosk/StoreMapContent.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useRef, useState } from "react";
 
+import { useAutoSTT } from '@/hooks/useAutoSTT';
+
 import { useRouter } from "next/navigation";
 
 declare global {
@@ -34,6 +36,10 @@ export default function StoreMapContent() {
     Record<string, { address: string; tel: string }>
   >({});
   const router = useRouter();
+  useAutoSTT({
+    '뒤로가기': () => router.back(),
+    '닫기': () => router.back(),
+  });
 
   useEffect(() => {
     const script = document.createElement("script");

--- a/src/components/kiosk/ThankYouScreen.tsx
+++ b/src/components/kiosk/ThankYouScreen.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { Language } from '@/lib/translations';
 import { useTTS } from '@/hooks/useTTS';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 
 interface ThankYouScreenProps {
   receiptType?: 'sms' | 'none';
@@ -25,6 +26,10 @@ export function ThankYouScreen({ receiptType, onNewSession, lang, t, onLanguageS
   const router = useRouter();
   const [countdown, setCountdown] = useState(AUTO_RESET_SECONDS);
   const { speak } = useTTS();
+  useAutoSTT({
+    '영수증출력': onNewSession,
+    '필요없어': onNewSession,
+  });
   useEffect(() => {
     speak('이용해 주셔서 감사합니다. 안전 운전하세요.');
   }, []);

--- a/src/components/kiosk/VehicleConfirmationScreen.tsx
+++ b/src/components/kiosk/VehicleConfirmationScreen.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import type { Language } from '@/lib/translations';
 import { useTTS } from '@/hooks/useTTS';
+import { useAutoSTT } from '@/hooks/useAutoSTT';
 
 interface VehicleConfirmationScreenProps {
   vehicleInfo: VehicleInfo;
@@ -33,6 +34,10 @@ export function VehicleConfirmationScreen({
   const [isManualEntryMode, setIsManualEntryMode] = useState(false);
   const [manualPlateInput, setManualPlateInput] = useState("");
   const { speak } = useTTS();
+  useAutoSTT({
+    '맞아': () => onConfirm(vehicleInfo),
+    '아니야': () => router.push('/manual-plate-input'),
+  });
   useEffect(() => {
     speak("차량 번호가 맞으신가요? 예 또는 아니요를 눌러주세요.");
   }, []);

--- a/src/hooks/useAutoSTT.ts
+++ b/src/hooks/useAutoSTT.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+
+export interface STTCommands {
+  [phrase: string]: () => void;
+}
+
+export function useAutoSTT(commands: STTCommands, duration = 10000) {
+  useEffect(() => {
+    const SpeechRecognition =
+      (window as any).webkitSpeechRecognition ||
+      (window as any).SpeechRecognition;
+    if (!SpeechRecognition) return;
+    const recognition = new SpeechRecognition();
+    recognition.lang = 'ko-KR';
+    recognition.interimResults = false;
+    recognition.continuous = false;
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const text = Array.from(event.results)
+        .map((r) => r[0].transcript)
+        .join('')
+        .replace(/\s/g, '');
+      Object.entries(commands).forEach(([phrase, callback]) => {
+        if (text.includes(phrase.replace(/\s/g, ''))) {
+          callback();
+        }
+      });
+    };
+
+    recognition.start();
+    const timer = setTimeout(() => recognition.stop(), duration);
+    return () => {
+      clearTimeout(timer);
+      recognition.stop();
+    };
+  }, [commands, duration]);
+}


### PR DESCRIPTION
## Summary
- create `useAutoSTT` hook for per-screen voice commands
- wire up STT across kiosk screens for 10-second automatic listening

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6853b500038483268a850c1ee064927e