### PR TITLE
Fix manual plate input flow

### DIFF
--- a/src/app/manual-plate-input/page.tsx
+++ b/src/app/manual-plate-input/page.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ManualPlateInputScreen } from '@/components/kiosk/ManualPlateInputScreen';
 import { Language, t as translateFunction } from '@/lib/translations';
+import { findVehicleByPlate } from '@/lib/vehicleLookup';
 
 export default function ManualPlateInputPage() {
   const router = useRouter();
@@ -38,7 +39,12 @@ export default function ManualPlateInputPage() {
   const handleSubmit = useCallback(
     (plate: string) => {
       console.log('License plate submitted:', plate);
-      router.push('/select-car-brand');
+      const vehicle = findVehicleByPlate(plate);
+      if (vehicle) {
+        router.push('/preauth');
+      } else {
+        router.push('/select-car-brand');
+      }
     },
     [router]
   );

--- a/src/components/kiosk/ManualPlateInputScreen.tsx
+++ b/src/components/kiosk/ManualPlateInputScreen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
@@ -20,7 +19,6 @@ interface ManualPlateInputScreenProps {
 
 export function ManualPlateInputScreen({ onSubmit, onCancel, lang, t, onLanguageSwitch }: ManualPlateInputScreenProps) {
   const [plate, setPlate] = useState('');
-  const router = useRouter();
 
   const languageButton = (
     <Button
@@ -36,7 +34,6 @@ export function ManualPlateInputScreen({ onSubmit, onCancel, lang, t, onLanguage
     const trimmed = plate.trim().toUpperCase();
     if (trimmed) {
       onSubmit(trimmed);
-      router.push('/select-car-brand');
     }
   };
 

--- a/src/lib/vehicleLookup.ts
+++ b/src/lib/vehicleLookup.ts
@@ -1,0 +1,15 @@
+export interface KnownVehicleInfo {
+  licensePlate: string;
+  brandId: string;
+  modelId: string;
+}
+
+export const KNOWN_VEHICLES: KnownVehicleInfo[] = [
+  { licensePlate: '12가3456', brandId: 'hyundai', modelId: 'ioniq5' },
+  { licensePlate: '34나7890', brandId: 'kia', modelId: 'ev6' },
+];
+
+export function findVehicleByPlate(plate: string): KnownVehicleInfo | undefined {
+  const normalized = plate.trim().toUpperCase();
+  return KNOWN_VEHICLES.find(v => v.licensePlate === normalized);
+}


### PR DESCRIPTION
## Summary
- add small vehicle lookup helper
- use vehicle lookup when submitting a plate from manual input page
- only navigate after handling in ManualPlateInputScreen
- support direct preauth navigation when vehicle info is known in main kiosk flow

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6853b8c824ac83268cc6b6554cecfb37