### PR TITLE
Add simpler voice commands for kiosk

### DIFF
--- a/src/components/kiosk/DataConsentScreen.tsx
+++ b/src/components/kiosk/DataConsentScreen.tsx
@@ -27,7 +27,9 @@ export function DataConsentScreen({ onAgree, onDisagree, disagreeTapCount, lang,
   const { speak } = useTTS();
   useAutoSTT({
     '동의합니다': onAgree,
+    '동의': onAgree,
     '비동의합니다': onDisagree,
+    '비동의': onDisagree,
   });
   useEffect(() => {
     speak("개인정보 수집 및 이용에 동의해 주세요.");

--- a/src/components/kiosk/InitialWelcomeScreen.tsx
+++ b/src/components/kiosk/InitialWelcomeScreen.tsx
@@ -23,6 +23,7 @@ export function InitialWelcomeScreen({ onProceedStandard, lang, t, onLanguageSwi
   const { speak } = useTTS();
   useAutoSTT({
     '서비스시작': onProceedStandard,
+    '시작': onProceedStandard,
     '빠른시작': () => router.push('/manual-plate-input'),
   });
   useEffect(() => {


### PR DESCRIPTION
## Summary
- trigger service guide on "시작" in initial welcome screen
- accept short commands "동의" and "비동의" in data consent screen

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853bd078f00832689f99a649773941d