### PR TITLE
Fix scroll jumping on manual input and brand screens

### DIFF
--- a/src/app/manual-plate-input/page.tsx
+++ b/src/app/manual-plate-input/page.tsx
@@ -41,16 +41,16 @@ export default function ManualPlateInputPage() {
       console.log('License plate submitted:', plate);
       const vehicle = findVehicleByPlate(plate);
       if (vehicle) {
-        router.push('/preauth');
+        router.push('/preauth', { scroll: false });
       } else {
-        router.push('/select-car-brand');
+        router.push('/select-car-brand', { scroll: false });
       }
     },
     [router]
   );
 
   const handleCancel = useCallback(() => {
-    router.push('/');
+    router.push('/', { scroll: false });
   }, [router]);
 
   if (!isClient) {

--- a/src/app/select-car-brand/page.tsx
+++ b/src/app/select-car-brand/page.tsx
@@ -34,11 +34,11 @@ export default function SelectCarBrandPage() {
   }, [lang]);
 
   const handleBrandSelect = useCallback((brandId: string) => {
-    router.push(`/select-car-model?brand=${brandId}`);
+    router.push(`/select-car-model?brand=${brandId}`, { scroll: false });
   }, [router]);
 
   const handleCancel = useCallback(() => {
-    router.push('/manual-plate-input');
+    router.push('/manual-plate-input', { scroll: false });
   }, [router]);
 
   if (!isClient) {

--- a/src/components/kiosk/SelectCarBrandScreen.tsx
+++ b/src/components/kiosk/SelectCarBrandScreen.tsx
@@ -33,7 +33,7 @@ export function SelectCarBrandScreen({ brands, onBrandSelect, onCancel, lang, t,
     const phrase = translate(brand.name);
     commandMap[phrase] = () => {
       onBrandSelect(brand.id);
-      router.push('/select-car-model');
+      router.push('/select-car-model', { scroll: false });
     };
   });
   commandMap['취소'] = onCancel;
@@ -65,13 +65,13 @@ export function SelectCarBrandScreen({ brands, onBrandSelect, onCancel, lang, t,
             className="p-4 flex flex-col items-center justify-center hover:shadow-lg cursor-pointer aspect-square transition-all hover:bg-muted/50"
             onClick={() => {
               onBrandSelect(brand.id);
-              router.push('/select-car-model');
+              router.push('/select-car-model', { scroll: false });
             }}
             tabIndex={0}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 onBrandSelect(brand.id);
-                router.push('/select-car-model');
+                router.push('/select-car-model', { scroll: false });
               }
             }}
             aria-label={translate(brand.name)}


### PR DESCRIPTION
## Summary
- keep scroll position when navigating to manual plate input or car brand select screens

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853be619f4c8326bce80f2617f9806e