### PR TITLE
Fix car brand navigation

### DIFF
--- a/src/components/kiosk/SelectCarBrandScreen.tsx
+++ b/src/components/kiosk/SelectCarBrandScreen.tsx
@@ -3,7 +3,6 @@
 
 import Image from 'next/image';
 import { Car } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
 import { Button } from '@/components/ui/button';
@@ -23,7 +22,6 @@ interface SelectCarBrandScreenProps {
 }
 
 export function SelectCarBrandScreen({ brands, onBrandSelect, onCancel, lang, t, onLanguageSwitch }: SelectCarBrandScreenProps) {
-  const router = useRouter();
   const translate = typeof t === 'function'
     ? t
     : (key: string, params?: Record<string, string | number>) => coreTranslate(lang, key, params);
@@ -33,7 +31,6 @@ export function SelectCarBrandScreen({ brands, onBrandSelect, onCancel, lang, t,
     const phrase = translate(brand.name);
     commandMap[phrase] = () => {
       onBrandSelect(brand.id);
-      router.push('/select-car-model', { scroll: false });
     };
   });
   commandMap['취소'] = onCancel;
@@ -65,13 +62,11 @@ export function SelectCarBrandScreen({ brands, onBrandSelect, onCancel, lang, t,
             className="p-4 flex flex-col items-center justify-center hover:shadow-lg cursor-pointer aspect-square transition-all hover:bg-muted/50"
             onClick={() => {
               onBrandSelect(brand.id);
-              router.push('/select-car-model', { scroll: false });
             }}
             tabIndex={0}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 onBrandSelect(brand.id);
-                router.push('/select-car-model', { scroll: false });
               }
             }}
             aria-label={translate(brand.name)}

--- a/src/components/kiosk/SelectCarModelScreen.tsx
+++ b/src/components/kiosk/SelectCarModelScreen.tsx
@@ -46,7 +46,7 @@ export function SelectCarModelScreen({ brand, onModelSelect, onCancel, lang, t, 
     </Button>
   );
   
-  if (!brand) {
+  if (!brand || brand.models.length === 0) {
     return (
       <FullScreenCard title={t("selectCarModel.error.noBrand")} bottomCenterAccessory={languageButton}>
         <CarIcon size={80} className="text-primary mb-6" />


### PR DESCRIPTION
## Summary
- ensure brand selection passes brand ID to next screen without losing query
- handle empty model lists in the car model screen

## Testing
- `npm run typecheck` *(fails: several type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6853c0eb13bc8326ad1381e647835b39