### PR TITLE
Fix layout shift for select car brand

### DIFF
--- a/src/components/kiosk/FullScreenCard.tsx
+++ b/src/components/kiosk/FullScreenCard.tsx
@@ -11,21 +11,25 @@ interface FullScreenCardProps {
 
 export function FullScreenCard({ children, className, title, bottomCenterAccessory }: FullScreenCardProps) {
   return (
-    <div className={cn(
-      'w-full h-full flex flex-col bg-card text-card-foreground animate-fade-in', // Root is flex-col
-      className
-    )}>
+    <div
+      className={cn(
+        "w-full min-h-dvh flex flex-col items-center justify-center relative bg-card text-card-foreground animate-fade-in",
+        className,
+      )}
+    >
       {/* Main scrollable content area */}
-      <div className="flex-grow w-full flex flex-col items-center justify-center p-6 sm:p-10 overflow-y-auto">
-        {title && <h1 className="text-4xl sm:text-5xl font-headline font-bold mb-8 text-center">{title}</h1>}
-        <div className="w-full flex flex-col items-center">
-          {children}
-        </div>
+      <div className="w-full flex flex-col items-center justify-center p-6 sm:p-10 pb-24 overflow-y-auto">
+        {title && (
+          <h1 className="text-4xl sm:text-5xl font-headline font-bold mb-8 text-center">
+            {title}
+          </h1>
+        )}
+        <div className="w-full flex flex-col items-center">{children}</div>
       </div>
 
       {/* Bottom center accessory area */}
       {bottomCenterAccessory && (
-        <div className="w-full py-4 px-6 flex justify-center items-center border-t border-border/30 shrink-0">
+        <div className="absolute bottom-0 left-0 right-0 py-4 px-6 flex justify-center items-center border-t border-border/30">
           {bottomCenterAccessory}
         </div>
       )}


### PR DESCRIPTION
## Summary
- keep FullScreenCard content vertically centered
- pin language button to page bottom without affecting layout

## Testing
- `npm run lint` *(fails: next not found/config prompts)*
- `npm run typecheck` *(fails: several type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853c38d3ce48326b2d342f38845c9dd