### PR TITLE
Fix quick start flow

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -291,7 +291,26 @@ export default function KioskPage() {
 
     console.log('Firebase Log (simulated): standard_mode_scan_simulated, vehicle_plate:', scannedVehicleInfo.licensePlate, 'timestamp:', new Date().toISOString(), 'language:', appData.language);
     
-    setKioskState('DATA_CONSENT'); 
+    setKioskState('DATA_CONSENT');
+  };
+
+  const handleProceedQuickStart = () => {
+    setAppData(prev => ({ ...prev, currentMode: 'quick' }));
+
+    const scannedVehicleInfo: VehicleInfo = {
+      ...MOCK_VEHICLE_DATA,
+      licensePlate: `AI-QCK-${Math.floor(Math.random() * 9000) + 1000}`,
+      confidence: 0.98,
+    };
+
+    setAppData(prev => ({
+      ...prev,
+      vehicleInfo: scannedVehicleInfo,
+    }));
+
+    console.log('Firebase Log (simulated): quick_start_scan_simulated, vehicle_plate:', scannedVehicleInfo.licensePlate, 'timestamp:', new Date().toISOString(), 'language:', appData.language);
+
+    setKioskState('DATA_CONSENT');
   };
 
   const handleConsentAgree = () => {
@@ -527,7 +546,7 @@ const handleConsentDisagree = () => {
       case 'PRE_PROCESSING_CAMERA_FEED':
         return <FullScreenCameraView {...screenProps} onProceedWithoutCamera={handleProceedFromFullScreenCamera} />;
       case 'INITIAL_WELCOME':
-        return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} />;
+        return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} onProceedQuickStart={handleProceedQuickStart} />;
       case 'DATA_CONSENT':
         return <DataConsentScreen {...screenProps} onAgree={handleConsentAgree} onDisagree={handleConsentDisagree} disagreeTapCount={disagreeTapCount} />;
       case 'MANUAL_PLATE_INPUT':
@@ -541,7 +560,7 @@ const handleConsentDisagree = () => {
         if (!appData.vehicleInfo) {
              console.warn("Missing vehicleInfo for VEHICLE_CONFIRMATION. Resetting.");
              resetToInitialWelcome();
-             return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} onSelectCarModelManually={() => setKioskState('SELECT_CAR_BRAND')}/>;
+             return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} onProceedQuickStart={handleProceedQuickStart} />;
         }
         return (
           <VehicleConfirmationScreen
@@ -563,14 +582,14 @@ const handleConsentDisagree = () => {
                 return <SlotAssignmentScreen {...screenProps} isQueue={!appData.currentSlots.some(s => s.status === 'available')}/>; 
              }
              resetToInitialWelcome();
-             return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} />;
+             return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} onProceedQuickStart={handleProceedQuickStart} />;
         }
         return <InitialPromptConnectScreen {...screenProps} vehicleInfo={appData.vehicleInfo} slotNumber={appData.assignedSlotId} onChargerConnected={handleChargerConnected} />;
       case 'DETECTING_CONNECTION':
         if (!appData.vehicleInfo) { 
              console.warn("Missing vehicle info for DETECTING_CONNECTION, showing SlotAssignment.");
              resetToInitialWelcome(); 
-             return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} />;
+             return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} onProceedQuickStart={handleProceedQuickStart} />;
         }
         return <DetectConnectionScreen {...screenProps} vehicleModelKey={appData.vehicleInfo.model} onDetectionComplete={handleConnectionDetected} />;
       case 'CONFIRM_START_CHARGING':
@@ -579,7 +598,7 @@ const handleConsentDisagree = () => {
         if (!appData.assignedSlotId || !appData.selectedConnectorType || !appData.vehicleInfo) {
           toast({ title: t('toast.error.noSlotInfo.title'), description: t('toast.error.noSlotInfo.description'), variant: "destructive" });
           resetToInitialWelcome();
-          return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} />;
+          return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} onProceedQuickStart={handleProceedQuickStart} />;
         }
         return <ChargingInProgressScreen
                   {...screenProps}
@@ -597,7 +616,7 @@ const handleConsentDisagree = () => {
              console.error("Final bill is null in CHARGING_COMPLETE_PAYMENT state. Resetting.");
              toast({ title: t('error.genericTitle'), description: "Error processing payment details.", variant: "destructive" });
              resetToInitialWelcome();
-             return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} />;
+             return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} onProceedQuickStart={handleProceedQuickStart} />;
          }
         return <PaymentScreen {...screenProps} bill={appData.finalBill} onPaymentProcessed={handlePaymentProcessed} />;
       case 'VACATE_SLOT_REMINDER':
@@ -614,7 +633,7 @@ const handleConsentDisagree = () => {
       default:
         console.warn('Unhandled kiosk state: ' + kioskState + ', resetting to initial welcome.');
         resetToInitialWelcome(); 
-        return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} />;
+        return <InitialWelcomeScreen {...screenProps} onProceedStandard={handleProceedFromInitialWelcome} onProceedQuickStart={handleProceedQuickStart} />;
     }
   };
 

--- a/src/components/kiosk/InitialWelcomeScreen.tsx
+++ b/src/components/kiosk/InitialWelcomeScreen.tsx
@@ -9,22 +9,21 @@ import type { Language } from '@/lib/translations';
 import { useEffect } from 'react';
 import { useTTS } from '@/hooks/useTTS';
 import { useAutoSTT } from '@/hooks/useAutoSTT';
-import { useRouter } from 'next/navigation';
 
 interface InitialWelcomeScreenProps {
   onProceedStandard: () => void;
+  onProceedQuickStart: () => void;
   lang: Language;
   t: (key: string, params?: Record<string, string | number>) => string;
   onLanguageSwitch: () => void;
 }
 
-export function InitialWelcomeScreen({ onProceedStandard, lang, t, onLanguageSwitch }: InitialWelcomeScreenProps) {
-  const router = useRouter();
+export function InitialWelcomeScreen({ onProceedStandard, onProceedQuickStart, lang, t, onLanguageSwitch }: InitialWelcomeScreenProps) {
   const { speak } = useTTS();
   useAutoSTT({
     '서비스시작': onProceedStandard,
     '시작': onProceedStandard,
-    '빠른시작': () => router.push('/manual-plate-input'),
+    '빠른시작': onProceedQuickStart,
   });
   useEffect(() => {
     speak("EV 충전 서비스를 시작합니다. 화면을 터치하거나 ‘시작’이라고 말씀해주세요.");
@@ -56,7 +55,7 @@ export function InitialWelcomeScreen({ onProceedStandard, lang, t, onLanguageSwi
           icon={<PlayCircle />}
         />
         <KioskButton
-          onClick={() => router.push('/manual-plate-input')}
+          onClick={onProceedQuickStart}
           label={t("initialWelcome.proceedButtonQuick")}
           icon={<Zap />}
         />

--- a/src/components/kiosk/VehicleConfirmationScreen.tsx
+++ b/src/components/kiosk/VehicleConfirmationScreen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import { CheckCircle2, Edit3 } from 'lucide-react';
 import { FullScreenCard } from './FullScreenCard';
 import { KioskButton } from './KioskButton';
@@ -30,13 +29,12 @@ export function VehicleConfirmationScreen({
   t,
   onLanguageSwitch,
 }: VehicleConfirmationScreenProps) {
-  const router = useRouter();
   const [isManualEntryMode, setIsManualEntryMode] = useState(false);
   const [manualPlateInput, setManualPlateInput] = useState("");
   const { speak } = useTTS();
   useAutoSTT({
     '맞아': () => onConfirm(vehicleInfo),
-    '아니야': () => router.push('/manual-plate-input'),
+    '아니야': () => setIsManualEntryMode(true),
   });
   useEffect(() => {
     speak("차량 번호가 맞으신가요? 예 또는 아니요를 눌러주세요.");
@@ -135,7 +133,7 @@ export function VehicleConfirmationScreen({
       <div className="w-full max-w-md space-y-4">
         <KioskButton onClick={() => onConfirm(vehicleInfo)} label={t("vehicleConfirmation.button.confirm")} icon={<CheckCircle2 />} />
         <KioskButton
-          onClick={() => router.push('/manual-plate-input')}
+          onClick={() => setIsManualEntryMode(true)}
           label={t("vehicleConfirmation.button.manualEntry")}
           variant="outline"
           icon={<Edit3 />}


### PR DESCRIPTION
## Summary
- hook up quick start button to kiosk state machine
- keep manual plate entry within confirmation screen

## Testing
- `npm run lint` *(fails: Next.js plugin interactive prompt)*
- `npm run typecheck` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853cdf7c164832692a3060e9cf362cc