### PR TITLE
Fix consent flow and charging error

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -321,27 +321,15 @@ export default function KioskPage() {
   };
 
 const handleConsentDisagree = () => {
-    // Since quick mode is removed, only standard mode logic applies here.
-    if (disagreeTapCount === 0) {
-        setDisagreeTapCount(1);
-        toast({
-            title: t('dataConsent.toast.disagreeWarning.title'),
-            description: t('dataConsent.toast.disagreeWarning.description'),
-            variant: "destructive",
-            duration: 7000,
-        });
-        console.log('Firebase Log (simulated): standard_mode_consent_disagree_first_tap, timestamp:', new Date().toISOString(), 'language:', appData.language);
-    } else { 
-        setAppData(prev => ({ ...prev, consentSkipped: true, currentMode: 'standard', vehicleInfo: null, selectedBrandId: null }));
-        console.log('Firebase Log (simulated): consent_skipped_proceed_manual, timestamp:', new Date().toISOString(), 'language:', appData.language);
-        toast({
-            title: t('dataConsent.toast.consentSkipped.title'),
-            description: t('dataConsent.toast.consentSkipped.description'),
-            duration: 5000,
-        });
-        setKioskState('MANUAL_PLATE_INPUT');
-        setDisagreeTapCount(0); 
-    }
+    toast({
+        title: t('dataConsent.toast.disagreeWarning.title'),
+        description: t('dataConsent.toast.disagreeWarning.description'),
+        variant: 'destructive',
+        duration: 7000,
+    });
+    console.log('Firebase Log (simulated): consent_disagreed, timestamp:', new Date().toISOString(), 'language:', appData.language);
+    setDisagreeTapCount(0);
+    resetToInitialWelcome();
 };
 
   const handleManualPlateSubmitted = useCallback((plate: string) => {

--- a/src/components/kiosk/ChargingInProgressScreen.tsx
+++ b/src/components/kiosk/ChargingInProgressScreen.tsx
@@ -284,11 +284,6 @@ export function ChargingInProgressScreen({
     }
   };
 
-  useAutoSTT({
-    '충전중지': handleManualStop,
-    '문제발생': handleSimulateErrorClick,
-  });
-
   const handleSimulateErrorClick = () => {
     if (chargeIntervalRef.current) {
       clearInterval(chargeIntervalRef.current);
@@ -300,6 +295,11 @@ export function ChargingInProgressScreen({
 
     onSimulateErrorRef.current("chargingError.messageCableDisconnect");
   };
+
+  useAutoSTT({
+    '충전중지': handleManualStop,
+    '문제발생': handleSimulateErrorClick,
+  });
 
   const displayPercentage = Math.min(currentChargePercentage, 100);
   const remainingTimeMinutes = Math.max(


### PR DESCRIPTION
## Summary
- redirect users to welcome screen when they disagree to data consent
- resolve initialization error in ChargingInProgressScreen

## Testing
- `npm run lint` *(fails: command prompts for ESLint setup)*
- `npm run typecheck` *(fails: type errors present)*

------
https://chatgpt.com/codex/tasks/task_e_6853d1abcca08326a517ff26167b45c6