### PR TITLE
Skip connector screen for quick start mode

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -437,9 +437,20 @@ const handleConsentDisagree = () => {
         }
     }
 
-    setKioskState('SELECT_CONNECTOR_TYPE');
+    if (appData.currentMode === 'quick') {
+      const autoConnectorType = appData.vehicleInfo?.recommendedConnectorType || 'ccs_combo_2';
+      const connector = MOCK_AVAILABLE_CONNECTORS.find(c => c.id === autoConnectorType);
+      const connectorName = connector ? t(connector.name) : autoConnectorType;
+      toast({
+        title: t('selectConnectorType.quickModeAutoSelect', { connectorName }),
+      });
+      setAppData(prev => ({ ...prev, selectedConnectorType: autoConnectorType }));
+      setKioskState('INITIAL_PROMPT_CONNECT');
+    } else {
+      setKioskState('SELECT_CONNECTOR_TYPE');
+    }
 
-  }, [appData.assignedSlotId, appData.currentSlots, appData.language, t, toast]);
+  }, [appData.assignedSlotId, appData.currentSlots, appData.currentMode, appData.vehicleInfo, appData.language, t, toast]);
 
   const handleConnectorTypeSelected = useCallback((connectorTypeId: string) => {
     setAppData(prev => ({ ...prev, selectedConnectorType: connectorTypeId }));


### PR DESCRIPTION
## Summary
- auto-skip connector selection when running in quick mode

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6853ddf4d154832696af7b94a30f5c1c