### PR TITLE
Fix camera detection and function init

### DIFF
--- a/src/components/kiosk/ChargingInProgressScreen.tsx
+++ b/src/components/kiosk/ChargingInProgressScreen.tsx
@@ -134,6 +134,31 @@ export function ChargingInProgressScreen({
     onSimulateErrorRef.current = onSimulateError;
   }, [onSimulateError]);
 
+  const handleManualStop = () => {
+    if (chargeIntervalRef.current) {
+      clearInterval(chargeIntervalRef.current);
+      chargeIntervalRef.current = null;
+    }
+
+    if (!isInternallyComplete) {
+      setIsInternallyComplete(true);
+      // Pass the most recent currentBill state directly for manual stop
+      setTimeout(() => onStopChargingRef.current(currentBill), 0);
+    }
+  };
+
+  const handleSimulateErrorClick = () => {
+    if (chargeIntervalRef.current) {
+      clearInterval(chargeIntervalRef.current);
+      chargeIntervalRef.current = null;
+    }
+    if (!isInternallyComplete) {
+      setIsInternallyComplete(true);
+    }
+
+    onSimulateErrorRef.current("chargingError.messageCableDisconnect");
+  };
+
   const [isStateLoaded, setIsStateLoaded] = useState(false);
 
   const [showConnectorWarning, setShowConnectorWarning] = useState(false);
@@ -270,31 +295,6 @@ export function ChargingInProgressScreen({
       }
     };
   }, [estimatedTotalTimeMinutes, costPerKwh, isInternallyComplete]);
-
-  const handleManualStop = () => {
-    if (chargeIntervalRef.current) {
-      clearInterval(chargeIntervalRef.current);
-      chargeIntervalRef.current = null;
-    }
-
-    if (!isInternallyComplete) {
-      setIsInternallyComplete(true);
-      // Pass the most recent currentBill state directly for manual stop
-      setTimeout(() => onStopChargingRef.current(currentBill), 0);
-    }
-  };
-
-  const handleSimulateErrorClick = () => {
-    if (chargeIntervalRef.current) {
-      clearInterval(chargeIntervalRef.current);
-      chargeIntervalRef.current = null;
-    }
-    if (!isInternallyComplete) {
-      setIsInternallyComplete(true);
-    }
-
-    onSimulateErrorRef.current("chargingError.messageCableDisconnect");
-  };
 
   useAutoSTT({
     '충전중지': handleManualStop,

--- a/src/components/kiosk/LiveCameraFeedScreen.tsx
+++ b/src/components/kiosk/LiveCameraFeedScreen.tsx
@@ -26,7 +26,7 @@ export function LiveCameraFeedScreen({ onScanComplete, lang, t, onLanguageSwitch
     const getCameraPermission = async () => {
       if (typeof navigator.mediaDevices?.getUserMedia !== 'function') {
         console.warn("Camera API not supported in this browser/context.");
-        setHasCameraPermission(false); 
+        setHasCameraPermission(false);
         toast({
           variant: 'destructive',
           title: t('liveCameraFeed.error.apiNotSupported.title'),
@@ -34,8 +34,21 @@ export function LiveCameraFeedScreen({ onScanComplete, lang, t, onLanguageSwitch
         });
         return;
       }
+
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const hasCamera = devices.some((device) => device.kind === 'videoinput');
+        if (!hasCamera) {
+          throw new Error('No camera device found');
+        }
+
+        const stream = await navigator.mediaDevices
+          .getUserMedia({ video: true })
+          .catch((e) => {
+            console.error('Camera access denied or not available', e);
+            throw e;
+          });
+
         setHasCameraPermission(true);
         if (videoRef.current) {
           videoRef.current.srcObject = stream;


### PR DESCRIPTION
## Summary
- detect camera with `enumerateDevices` before calling `getUserMedia`
- move charging handler functions above hooks to avoid initialization errors

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853e012034c8326958829501b4bd01b