### PR TITLE
Change initial screen to greeting

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,7 +94,7 @@ const CURRENT_STATE_KEY = 'kioskCurrentState';
 const CURRENT_APPDATA_KEY = 'kioskCurrentAppData';
 
 export default function KioskPage() {
-  const [kioskState, setKioskState] = useState<KioskState>('PRE_PROCESSING_CAMERA_FEED');
+  const [kioskState, setKioskState] = useState<KioskState>('INITIAL_WELCOME');
   const [appData, setAppData] = useState<AppData>(MOCK_INITIAL_APP_DATA);
   const [disagreeTapCount, setDisagreeTapCount] = useState(0);
   const { toast } = useToast();

--- a/src/types/kiosk.ts
+++ b/src/types/kiosk.ts
@@ -76,7 +76,7 @@ export interface NoticeItem {
 
 
 export type KioskState =
-  | 'PRE_PROCESSING_CAMERA_FEED' // New initial state
+  | 'PRE_PROCESSING_CAMERA_FEED'
   | 'INITIAL_WELCOME'
   | 'LIVE_CAMERA_FEED'
   | 'DATA_CONSENT'


### PR DESCRIPTION
## Summary
- set the kiosk's default state to `INITIAL_WELCOME` so the greeting screen is shown first
- update KioskState comment in types

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861dbc84f708326b74bf65ddd3d6663