### PR TITLE
Map Tesla Model Y to Niro on charger UI

### DIFF
--- a/src/components/kiosk/DetectConnectionScreen.tsx
+++ b/src/components/kiosk/DetectConnectionScreen.tsx
@@ -19,7 +19,9 @@ export function DetectConnectionScreen({ vehicleModelKey, onDetectionComplete, l
   const [status, setStatus] = useState<'detecting' | 'success'>('detecting');
   const [progressValue, setProgressValue] = useState(10); 
 
-  const vehicleModelDisplay = t(vehicleModelKey);
+  const vehicleModelDisplayRaw = t(vehicleModelKey);
+  const vehicleModelDisplay =
+    vehicleModelDisplayRaw === '모델 Y' ? '니로' : vehicleModelDisplayRaw;
 
   useEffect(() => {
     let timer: NodeJS.Timeout | undefined = undefined;

--- a/src/components/kiosk/InitialPromptConnectScreen.tsx
+++ b/src/components/kiosk/InitialPromptConnectScreen.tsx
@@ -22,7 +22,9 @@ interface InitialPromptConnectScreenProps {
 }
 
 export function InitialPromptConnectScreen({ vehicleInfo, slotNumber, onChargerConnected, lang, t, onLanguageSwitch }: InitialPromptConnectScreenProps) {
-  const vehicleModelDisplay = vehicleInfo.model ? t(vehicleInfo.model) : t('selectCarModel.unknownModel');
+  const vehicleModelDisplayRaw = vehicleInfo.model ? t(vehicleInfo.model) : t('selectCarModel.unknownModel');
+  const vehicleModelDisplay =
+    vehicleModelDisplayRaw === '모델 Y' ? '니로' : vehicleModelDisplayRaw;
   const portLocationDisplay = vehicleInfo.portLocationDescription ? t(vehicleInfo.portLocationDescription) : "";
   const { speak } = useTTS();
   useAutoSTT({ '연결했어': onChargerConnected });


### PR DESCRIPTION
## Summary
- show `니로` instead of `모델 Y` on the charger connection screens
- adjust DetectConnectionScreen and InitialPromptConnectScreen for the new display mapping

## Testing
- `npm run typecheck` *(fails: numerous TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861fd22912483269ff05b055ea43c10