### PR TITLE
Ensure TTS uses on-screen translations

### DIFF
--- a/src/components/kiosk/ChargingInProgressScreen.tsx
+++ b/src/components/kiosk/ChargingInProgressScreen.tsx
@@ -62,11 +62,7 @@ export function ChargingInProgressScreen({
   selectedConnectorType,
 }: ChargingInProgressScreenProps) {
   const { speak } = useTTS();
-  useEffect(() => {
-    speak(
-      "충전이 진행 중입니다. 필요 시 중지하거나 문제 해결 버튼을 눌러주세요. 시스템 보호를 위해 강제로 커넥터를 제거하지 마세요. 충전이 완료될 때까지 기다려 주세요."
-    );
-  }, []);
+  // Removed custom TTS message to ensure spoken text matches on-screen content
   const loadStateFromSessionStorage = (): StoredChargingState | null => {
     if (typeof window !== "undefined") {
       const saved = sessionStorage.getItem(SESSION_STORAGE_KEY);

--- a/src/components/kiosk/ConfirmStartChargingScreen.tsx
+++ b/src/components/kiosk/ConfirmStartChargingScreen.tsx
@@ -25,8 +25,8 @@ export function ConfirmStartChargingScreen({ onStart, onCancel, lang, t, onLangu
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const { speak } = useTTS();
   useEffect(() => {
-    speak("충전 준비가 완료되었습니다. 곧 충전이 시작됩니다.");
-  }, []);
+    speak(t("confirmStartCharging.instruction"));
+  }, [t]);
 
   useEffect(() => {
     timerRef.current = setInterval(() => {

--- a/src/components/kiosk/DataConsentScreen.tsx
+++ b/src/components/kiosk/DataConsentScreen.tsx
@@ -32,8 +32,8 @@ export function DataConsentScreen({ onAgree, onDisagree, disagreeTapCount, lang,
     '비동의': onDisagree,
   });
   useEffect(() => {
-    speak("개인정보 수집 및 이용에 동의해 주세요.");
-  }, []);
+    speak(t("dataConsent.p4_agree"));
+  }, [t]);
   const languageButton = (
     <Button
       onClick={onLanguageSwitch}

--- a/src/components/kiosk/InitialPromptConnectScreen.tsx
+++ b/src/components/kiosk/InitialPromptConnectScreen.tsx
@@ -29,8 +29,12 @@ export function InitialPromptConnectScreen({ vehicleInfo, slotNumber, onChargerC
   const { speak } = useTTS();
   useAutoSTT({ '연결했어': onChargerConnected });
   useEffect(() => {
-    speak("테슬라 Y: 좌측 뒤에 라이트쪽에 충전구가 있습니다.");
-  }, []);
+    let message = t("initialPromptConnect.instruction", { vehicleModel: vehicleModelDisplay });
+    if (portLocationDisplay) {
+      message += " " + t("initialPromptConnect.portLocation", { portLocationDescription: portLocationDisplay });
+    }
+    speak(message);
+  }, [t, vehicleModelDisplay, portLocationDisplay]);
 
    let connectionImagePath = vehicleInfo.connectionImageUrl;
 

--- a/src/components/kiosk/InitialWelcomeScreen.tsx
+++ b/src/components/kiosk/InitialWelcomeScreen.tsx
@@ -26,8 +26,8 @@ export function InitialWelcomeScreen({ onProceedStandard, onProceedQuickStart, l
     '빠른시작': onProceedQuickStart,
   });
   useEffect(() => {
-    speak("EV 충전 서비스를 시작합니다. 화면을 터치하거나 ‘시작’이라고 말씀해주세요.");
-  }, []);
+    speak(t("initialWelcome.greeting"));
+  }, [t]);
   const languageButton = (
     <Button
       onClick={onLanguageSwitch}

--- a/src/components/kiosk/PaymentScreen.tsx
+++ b/src/components/kiosk/PaymentScreen.tsx
@@ -28,15 +28,15 @@ export function PaymentScreen({ bill, onPaymentProcessed, lang, t, onLanguageSwi
 
   useEffect(() => {
     if (paymentStatus === 'pending') {
-      speak('충전이 완료되었습니다. 결제를 진행합니다. 결제가 완료되면 충전 커넥터를 분리해 주세요.');
+      speak(`${t('payment.title.complete')} ${t('payment.instruction.disconnect')}`);
     }
-  }, [paymentStatus]);
+  }, [paymentStatus, t]);
 
   useEffect(() => {
     if (paymentStatus === 'success') {
-      speak('결제가 완료되었습니다. 영수증을 인쇄하거나 화면에서 확인할 수 있습니다.');
+      speak(t('payment.success.title'));
     }
-  }, [paymentStatus]);
+  }, [paymentStatus, t]);
 
   const handlePaymentMethodSelect = (method: PaymentMethod) => {
     setSelectedPaymentMethod(method);

--- a/src/components/kiosk/PrePaymentAuthScreen.tsx
+++ b/src/components/kiosk/PrePaymentAuthScreen.tsx
@@ -23,8 +23,8 @@ export function PrePaymentAuthScreen({ onAuthSuccess, onCancel, lang, t, onLangu
   const [processingMethod, setProcessingMethod] = useState<'card' | 'nfc' | null>(null);
   const { speak } = useTTS();
   useEffect(() => {
-    speak("결제를 진행하기 전에 인증을 완료해 주세요.");
-  }, []);
+    speak(t("prePaymentAuth.instruction"));
+  }, [t]);
 
   const handleSimulatePayment = (method: 'card' | 'nfc') => {
     setProcessingMethod(method);

--- a/src/components/kiosk/SelectConnectorTypeScreen.tsx
+++ b/src/components/kiosk/SelectConnectorTypeScreen.tsx
@@ -41,8 +41,8 @@ export function SelectConnectorTypeScreen({
   useAutoSTT(commandMap);
 
   useEffect(() => {
-    speak("차량에 맞는 충전 커넥터를 선택해 주세요.");
-  }, []);
+    speak(t("selectConnectorType.instruction"));
+  }, [t]);
 
   const recommendedTypeId = vehicleInfo?.recommendedConnectorType;
   const vehicleModelDisplayRaw = vehicleInfo?.model ? t(vehicleInfo.model) : "";

--- a/src/components/kiosk/ThankYouScreen.tsx
+++ b/src/components/kiosk/ThankYouScreen.tsx
@@ -30,9 +30,6 @@ export function ThankYouScreen({ receiptType, onNewSession, lang, t, onLanguageS
     '영수증출력': onNewSession,
     '필요없어': onNewSession,
   });
-  useEffect(() => {
-    speak('이용해 주셔서 감사합니다. 안전 운전하세요.');
-  }, []);
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -46,6 +43,10 @@ export function ThankYouScreen({ receiptType, onNewSession, lang, t, onLanguageS
   if (receiptType === 'sms') {
     receiptMessageKey = "thankYou.message.smsSent";
   }
+
+  useEffect(() => {
+    speak(t(receiptMessageKey));
+  }, [t, receiptMessageKey]);
 
   const languageButton = (
     <Button

--- a/src/components/kiosk/VehicleConfirmationScreen.tsx
+++ b/src/components/kiosk/VehicleConfirmationScreen.tsx
@@ -37,8 +37,8 @@ export function VehicleConfirmationScreen({
     '아니야': () => setIsManualEntryMode(true),
   });
   useEffect(() => {
-    speak("차량 번호가 맞으신가요? 예 또는 아니요를 눌러주세요.");
-  }, []);
+    speak(t("vehicleConfirmation.question"));
+  }, [t]);
 
   const handleManualSubmit = () => {
   if (manualPlateInput.trim() === "") return;

--- a/src/components/kiosk/VoiceRecognitionButton.tsx
+++ b/src/components/kiosk/VoiceRecognitionButton.tsx
@@ -62,19 +62,19 @@ export function VoiceRecognitionButton() {
   };
 
   if (normalized.includes("충전시작") || normalized.includes("충전")) {
-    speak("충전을 시작합니다.");
+    // speak("충전을 시작합니다.");
     router.push("/charging");
   } else if (normalized.includes("결제")) {
-    speak("결제 화면으로 이동합니다.");
+    // speak("결제 화면으로 이동합니다.");
     router.push("/payment");
   } else if (normalized.includes("처음") || normalized.includes("홈")) {
-    speak("처음 화면으로 이동합니다.");
+    // speak("처음 화면으로 이동합니다.");
     router.push("/");
   } else if (normalized.includes("도움말")) {
-    speak("도움말 화면으로 이동합니다.");
+    // speak("도움말 화면으로 이동합니다.");
     router.push("/help");
   } else if (normalized.includes("설정")) {
-    speak("설정 화면으로 이동합니다.");
+    // speak("설정 화면으로 이동합니다.");
     router.push("/settings");
   } else if (
     normalized.includes("다음") ||
@@ -85,10 +85,10 @@ export function VoiceRecognitionButton() {
       'button[data-variant="default"]:not([aria-label="Start voice recognition"])'
     ) as HTMLButtonElement | null;
     if (nextButton) {
-      speak("다음 단계로 이동합니다.");
+      // speak("다음 단계로 이동합니다.");
       nextButton.click();
     } else {
-      speak("다음 단계로 이동할 수 없습니다.");
+      // speak("다음 단계로 이동할 수 없습니다.");
       toast({
         title: "다음 단계 없음",
         description: "이 화면에서는 다음 단계 버튼을 찾을 수 없습니다.",
@@ -101,7 +101,7 @@ export function VoiceRecognitionButton() {
       description: `"${text}" 명령을 처리할 수 없습니다.`,
       variant: "destructive",
     });
-    speak("죄송합니다. 명령을 이해하지 못했습니다.");
+    // speak("죄송합니다. 명령을 이해하지 못했습니다.");
   }
 
   // ✅ 로그 저장


### PR DESCRIPTION
## Summary
- align all TTS prompts with visible text by using `t()` translations
- remove unmatched TTS messages

## Testing
- `npm run lint` *(fails: Next.js eslint setup prompt)*
- `npm run typecheck` *(fails: multiple TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68620ba193508326a6ab447ad1309d7e